### PR TITLE
fix minor typo in Boost.Geometry release note.

### DIFF
--- a/feed/history/boost_1_56_0.qbk
+++ b/feed/history/boost_1_56_0.qbk
@@ -220,7 +220,7 @@ All header paths should remain the same. The new modules are:
     * New algorithm is_simple, returning true if a geometry is simple according to the OGC standard
     * New algorithm is_valid, returning true if a geometry is valid according to the OGC standard
     * New algorithm crosses for checking this spatial relation according to the OGC standard
-    * The set operation algorithms (difference, intersection, sym_difference and union) now support as input pairs of pointlike or linear geometries
+    * The set operation algorithms (difference, intersection, sym_difference and union_) now support as input pairs of pointlike or linear geometries
     * The distance and comparable_distance algorithms now support all pairs of geometry combinations
     * The spatial relations which didn't support it (covered_by, touches, within, etc.) now support as input linear and/or areal geometries
     * The support for boost::variants as input geometries in various algorithms


### PR DESCRIPTION
`union` is keyword. correct function name is `union_`. see documentation:
http://www.boost.org/doc/libs/1_55_0/libs/geometry/doc/html/geometry/reference/algorithms/union_.html
