### PR TITLE
add references to Boost Library Incubator to review process pages

### DIFF
--- a/community/reviews.html
+++ b/community/reviews.html
@@ -75,7 +75,9 @@ http://www.boost.org/development/website_updating.html
               Review comments:</p>
 
               <ul>
-                <li>Publicly on the mailing list.</li>
+                <li>Publicly on the mailing list or the <a href=
+                "http://blincubator.com">Boost Library Incubator</a>.
+                </li>
 
                 <li>Privately to the Review Manager.</li>
               </ul>
@@ -169,7 +171,9 @@ http://www.boost.org/development/website_updating.html
                 <li>Checks the submission to make sure it really is complete
                 enough to warrant formal review. See the <a href=
                 "/development/requirements.html">Boost Library Requirements
-                and Guidelines</a>. If necessary, work with the submitter to
+                and Guidelines</a>. Submitting through the <a href=
+                "http://blincubator.com">Boost Library Incubator</a> will
+                verify many of the requirements. If necessary, work with the submitter to
                 verify the code compiles and runs correctly on several
                 compilers and platforms.</li>
 

--- a/development/submissions.html
+++ b/development/submissions.html
@@ -79,7 +79,8 @@ http://www.boost.org/development/website_updating.html
               interest</h2>
 
               <p>Potential library submitters should use the Boost developers
-              <a href="/community/groups.html">mailing list</a> as a forum to
+              <a href="/community/groups.html">mailing list</a> and <a href=
+-              "http://blincubator.com">Boost Library Incubator</a> as forums to
               gauge interest a possible submission.</p>
 
               <p>A message might be as simple as "Is there any interest in a
@@ -102,6 +103,10 @@ http://www.boost.org/development/website_updating.html
               <p>If response to an initial query indicates interest,
               then make your preliminary submission publicly available
               if you haven't already done so.</p>
+
+              <p>You can receive preliminary feedback and reviews by
+              submitting your library to the <a href=
+              "http://blincubator.com">Boost Library Incubator</a>.</p>
 
               <h2><a name="Refinement" id="Refinement"></a>Refinement</h2>
 


### PR DESCRIPTION
This is four minimal changes to the review process pages to add references to the Boost Library Incubator where appropriate.
