### PR TITLE
On 18 July 2014, Ohloh became Black Duck Open Hub.

### DIFF
--- a/development/index.html
+++ b/development/index.html
@@ -12,23 +12,23 @@
 
   <style type="text/css">
 /*<![CDATA[*/
-  #content .section .ohloh > div {
+  #content .section .openhub > div {
   background: transparent !important;
   }
-  #content .section .ohloh table {
+  #content .section .openhub table {
   background: transparent !important;
   clear: none !important;
   border-spacing: 0em !important;
   margin-bottom: 0.25em !important;
   }
-  #content .section .ohloh table tr td {
+  #content .section .openhub table tr td {
   border: none !important;
   }
-  #content .section #ohloh-cost table tr td {
+  #content .section #openhub-cost table tr td {
   background: transparent !important;
   border-bottom: 1px #DDD solid !important;
   }
-  #content .section .ohloh img {
+  #content .section .openhub img {
   border: none !important;
   padding: 0em !important;
   }
@@ -62,39 +62,36 @@ http://www.boost.org/development/website_updating.html
               in the development discussion. But if you are looking for an
               "easy" place to get your feet wet is to voluteer <a href=
               "testing.html">testing</a> resources. The wonderful people at
-              <a href="http://www.ohloh.net/" class="external">Ohloh</a>
-              provide a peek into what goes into Boost:</p>
+              <a href="http://www.openhub.net/" class="external">Black Duck
+              Open Hub</a> provide a peek into what goes into Boost:</p>
 
-              <ul class="directory" id="ohloh-languages">
-                <li class="ohloh">
+              <ul class="directory" id="openhub-languages">
+                <li class="openhub">
                   <script type="text/javascript" src=
-                  "http://www.ohloh.net/projects/3/widgets/project_languages">
+                  "http://www.openhub.net/p/3/widgets/project_languages.js">
 </script>
                 </li>
 
-                <li class="ohloh" id="ohloh-cost">
+                <li class="openhub" id="openhub-cost">
                   <script type="text/javascript" src=
-                  "http://www.ohloh.net/projects/3/widgets/project_cocomo">
+                  "http://www.openhub.net/p/3/widgets/project_cocomo.js">
 </script>
                 </li>
               </ul>
             </div>
-            
+
             <div class="section-title">
               <h1>Release Schedule</h1>
             </div>
 
             <div class="section-body">
               <p>Below is a community maintained calendar of Boost related
-              events. The release managers try to keep the
-              release related portion of the calendar up to date.</p>
-              <iframe src=
+              events. The release managers try to keep the release related
+              portion of the calendar up to date.</p><iframe src=
               "http://www.google.com/calendar/embed?src=5rorfm42nvmpt77ac0vult9iig%40group.calendar.google.com&amp;ctz=America/Chicago"
               class="c1" width="100%" height="600" frameborder="0" scrolling=
-              "no">
-              </iframe>
+              "no"></iframe>
             </div>
-            
           </div>
         </div>
       </div>


### PR DESCRIPTION
On 18 July 2014, Ohloh became Black Duck Open Hub.

https://twitter.com/bdopenhub/status/490265903519760384
