### PR TITLE
Boost.Fusion changelog for Boost 1.58.0

### DIFF
--- a/feed/history/boost_1_58_0.qbk
+++ b/feed/history/boost_1_58_0.qbk
@@ -61,6 +61,22 @@
     clashes with legacy code where this support has already been defined by the user.
   * Maintenance fixes.
 
+* [phrase library..[@/libs/fusion/ Fusion]:]
+  * New ADAPT_STRUCT, ADAPT_ADT, ADAPT_ASSOC_ that deduce the members types ([ticket 9516]).
+  * Add convert implementation for Boost.Tuple and std::tuple.
+  * Add mpl::clear implementation for Boost.Tuple and std::tuple.
+  * Use boost::declval instead of std::declval, ([ticket 10190]).
+  * Fix tuple heading, close ([ticket 5324]).
+  * Fix document typo, close ([ticket 6090]).
+  * Remove use of `boost::blank` ([ticket 8622]).
+  * Add result_of::{copy,move} ([ticket 5886]).
+  * Better constexpr and noexcept support.
+  * SFINAE Friendly result_of ([ticket 10676]). 
+  * SFINAE Friendly invoke ([ticket 10443]).
+  * result_of::size::value and result_of::size::type::value are the same type now ([ticket 7304])
+  * Fix missing includes ([ticket 8457]).
+  * result_of::at<Seq, N>::type is now defined when sizeof of sequence is less than N ([ticket 6507], [ticket 7651]) 
+  * Many documentation fixes & improvements ([ticket 6090]).
 
 * [phrase library..[@/libs/multi_index/index.html Multi-index Containers]:]
   * The efficiency of lookup operations has improved in situations where they involve the generation

--- a/feed/history/boost_1_58_0.qbk
+++ b/feed/history/boost_1_58_0.qbk
@@ -62,21 +62,19 @@
   * Maintenance fixes.
 
 * [phrase library..[@/libs/fusion/ Fusion]:]
+  * Automatic hash creation function ([@https://github.com/boostorg/fusion/pull/12 Github PR #12])
   * New ADAPT_STRUCT, ADAPT_ADT, ADAPT_ASSOC_ that deduce the members types ([ticket 9516]).
   * Add convert implementation for Boost.Tuple and std::tuple.
   * Add mpl::clear implementation for Boost.Tuple and std::tuple.
   * Use boost::declval instead of std::declval, ([ticket 10190]).
-  * Fix tuple heading, close ([ticket 5324]).
-  * Fix document typo, close ([ticket 6090]).
   * Remove use of `boost::blank` ([ticket 8622]).
   * Add result_of::{copy,move} ([ticket 5886]).
   * Better constexpr and noexcept support.
-  * SFINAE Friendly result_of ([ticket 10676]). 
-  * SFINAE Friendly invoke ([ticket 10443]).
+  * Improved SFINAE Friendliness of many metafunctions ([ticket 10676], [ticket 10443]). 
   * result_of::size::value and result_of::size::type::value are the same type now ([ticket 7304])
-  * Fix missing includes ([ticket 8457]).
   * result_of::at<Seq, N>::type is now defined when sizeof of sequence is less than N ([ticket 6507], [ticket 7651]) 
-  * Many documentation fixes & improvements ([ticket 6090]).
+  * Fix missing includes ([ticket 8457]).
+  * Many documentation fixes & improvements ([ticket 6090] [ticket 5324] [@https://github.com/boostorg/fusion/pull/33 GitHub PR #33] [@https://github.com/boostorg/fusion/pull/53 GitHub PR #53] [@https://github.com/boostorg/fusion/pull/56 GitHub PR #56] )
 
 * [phrase library..[@/libs/multi_index/index.html Multi-index Containers]:]
   * The efficiency of lookup operations has improved in situations where they involve the generation

--- a/feed/history/boost_1_58_0.qbk
+++ b/feed/history/boost_1_58_0.qbk
@@ -70,7 +70,7 @@
   * Remove use of `boost::blank` ([ticket 8622]).
   * Add result_of::{copy,move} ([ticket 5886]).
   * Better constexpr and noexcept support.
-  * Improved SFINAE Friendliness of many metafunctions ([ticket 10676], [ticket 10443]). 
+  * Improved SFINAE Friendliness of many metafunctions ([ticket 10676] [ticket 10443]). 
   * result_of::size::value and result_of::size::type::value are the same type now ([ticket 7304])
   * result_of::at<Seq, N>::type is now defined when sizeof of sequence is less than N ([ticket 6507], [ticket 7651]) 
   * Fix missing includes ([ticket 8457]).


### PR DESCRIPTION
Dear @danieljames,

Please find the updated release notes for Boost 1.58.0 with Boost.Fusion changes as merged in boostorg/fusion#48 and boostorg/fusion#55.

These changelog were discussed with @Flast and @djowel in boostorg/fusion#55.

Cheers,