### PR TITLE
[1.58.0] Move release note : remove duplicate identifier

### DIFF
--- a/feed/history/boost_1_58_0.qbk
+++ b/feed/history/boost_1_58_0.qbk
@@ -161,7 +161,7 @@ to test this.
   * Switched documentation to use SVG rather than PNG graphs and equations - browsers seem to have finally caught up!
 
 * [phrase library..[@/libs/move/ Move]:]
-  * Added `BOOST_MOVE_BASE BOOST_MOVE_BASE` utility.
+  * Added `BOOST_MOVE_BASE` utility.
   * Added `adl_move_swap` utility.
   * Reduced dependencies on other Boost libraries to make the library a bit more lightweight.
   * Fixed bugs:


### PR DESCRIPTION
`BOOST_MOVE_BASE BOOST_MOVE_BASE`

to

`BOOST_MOVE_BASE`