### PR TITLE
notice about support of Windows Fibers

### DIFF
--- a/feed/history/boost_1_59_0.qbk
+++ b/feed/history/boost_1_59_0.qbk
@@ -42,6 +42,7 @@
   
 * [phrase library..[@/libs/context/ Context]:]
   * [ticket 11223] check support for std::integer_sequence
+  * execution_context uses internally Windows Fibers with BOOST_USE_WINFIBERS 
  
 * [phrase library..[@/libs/coroutine/ Coroutine]:]
   * [ticket 10978] remove additional semicolons


### PR DESCRIPTION
execution_context of boost.context switches its internal implementation to Windows Fibers wit hcompiler flag BOOST_USE_WINFIBERS