### PR TITLE
BUGFIX: Fixing patch paths proposed in #82 to make it appliable on released boost zip

### DIFF
--- a/patches/1_58_0/0002-Fix-a-regression-with-non-constexpr-types.patch
+++ b/patches/1_58_0/0002-Fix-a-regression-with-non-constexpr-types.patch
@@ -1,7 +1,7 @@
-diff --git a/include/boost/fusion/adapted/struct/detail/define_struct.hpp b/include/boost/fusion/adapted/struct/detail/define_struct.hpp
+diff --git a/boost/fusion/adapted/struct/detail/define_struct.hpp b/boost/fusion/adapted/struct/detail/define_struct.hpp
 index 2554292..ce3737e 100644
---- a/include/boost/fusion/adapted/struct/detail/define_struct.hpp
-+++ b/include/boost/fusion/adapted/struct/detail/define_struct.hpp
+--- a/boost/fusion/adapted/struct/detail/define_struct.hpp
++++ b/boost/fusion/adapted/struct/detail/define_struct.hpp
 @@ -69,7 +69,7 @@
      ATTRIBUTES_SEQ, ATTRIBUTE_TUPEL_SIZE)                                       \
                                                                                  \
@@ -74,10 +74,10 @@ index 2554292..ce3737e 100644
          NAME(BOOST_PP_SEQ_FOR_EACH_I_R(                                         \
                  1,                                                              \
                  BOOST_FUSION_DEFINE_STRUCT_CTOR_ARG_I,                          \
-diff --git a/include/boost/fusion/adapted/struct/detail/define_struct_inline.hpp b/include/boost/fusion/adapted/struct/detail/define_struct_inline.hpp
+diff --git a/boost/fusion/adapted/struct/detail/define_struct_inline.hpp b/boost/fusion/adapted/struct/detail/define_struct_inline.hpp
 index a5a3ae0..a037ffe 100644
---- a/include/boost/fusion/adapted/struct/detail/define_struct_inline.hpp
-+++ b/include/boost/fusion/adapted/struct/detail/define_struct_inline.hpp
+--- a/boost/fusion/adapted/struct/detail/define_struct_inline.hpp
++++ b/boost/fusion/adapted/struct/detail/define_struct_inline.hpp
 @@ -66,7 +66,7 @@
  #define BOOST_FUSION_IGNORE_2(ARG1, ARG2)
  
@@ -96,10 +96,10 @@ index a5a3ae0..a037ffe 100644
          BOOST_FUSION_ITERATOR_NAME(NAME)(boost_fusion_detail_Seq& seq)          \
              : seq_(seq)                                                         \
                BOOST_FUSION_DEFINE_ITERATOR_WKND_INIT_LIST_ENTRIES(              \
-diff --git a/test/sequence/adapt_struct.cpp b/test/sequence/adapt_struct.cpp
+diff --git a/libs/fusion/test/sequence/adapt_struct.cpp b/libs/fusion/test/sequence/adapt_struct.cpp
 index c0cd304..121827f 100644
---- a/test/sequence/adapt_struct.cpp
-+++ b/test/sequence/adapt_struct.cpp
+--- a/libs/fusion/test/sequence/adapt_struct.cpp
++++ b/libs/fusion/test/sequence/adapt_struct.cpp
 @@ -67,6 +67,17 @@ namespace ns
          foo foo_;
          int y;
@@ -161,10 +161,10 @@ index c0cd304..121827f 100644
      return boost::report_errors();
  }
  
-diff --git a/test/sequence/define_struct.cpp b/test/sequence/define_struct.cpp
+diff --git a/libs/fusion/test/sequence/define_struct.cpp b/libs/fusion/test/sequence/define_struct.cpp
 index 795fdf6..63b5a19 100644
---- a/test/sequence/define_struct.cpp
-+++ b/test/sequence/define_struct.cpp
+--- a/libs/fusion/test/sequence/define_struct.cpp
++++ b/libs/fusion/test/sequence/define_struct.cpp
 @@ -26,6 +26,14 @@ BOOST_FUSION_DEFINE_STRUCT(
  
  BOOST_FUSION_DEFINE_STRUCT(BOOST_PP_EMPTY(), s, (int, m))
@@ -195,10 +195,10 @@ index 795fdf6..63b5a19 100644
      return boost::report_errors();
  }
  
-diff --git a/test/sequence/define_struct_inline.cpp b/test/sequence/define_struct_inline.cpp
+diff --git a/libs/fusion/test/sequence/define_struct_inline.cpp b/libs/fusion/test/sequence/define_struct_inline.cpp
 index e849ce9..d34a142 100644
---- a/test/sequence/define_struct_inline.cpp
-+++ b/test/sequence/define_struct_inline.cpp
+--- a/libs/fusion/test/sequence/define_struct_inline.cpp
++++ b/libs/fusion/test/sequence/define_struct_inline.cpp
 @@ -41,6 +41,13 @@ namespace ns
      BOOST_FUSION_DEFINE_STRUCT_INLINE(s, (int, m))
              


### PR DESCRIPTION
Hi @danieljames,

Thanks to @Arfrever I noticed that the patch for Boost 1.58.0 proposed in #82 is not working on a released zip package Boost tree.

I fixed the paths so that one can apply from the top-level directory of the Boost zip distribution.

I applied it successfully with : `git apply 0002-Fix-a-regression-with-non-constexpr-types.patch`

Cheers,
