### PR TITLE
Updated change log for boost.test v3

### DIFF
--- a/feed/history/boost_1_59_0.qbk
+++ b/feed/history/boost_1_59_0.qbk
@@ -39,15 +39,33 @@
 * [phrase library..[@/libs/multi_index/index.html Multi-index Containers]:]
   * Added [@/libs/multi_index/doc/tutorial/indices.html#rnk_indices ranked indices].
   * Maintenance fixes.
-  
+
 * [phrase library..[@/libs/context/ Context]:]
   * [ticket 11223] check support for std::integer_sequence
- 
+
 * [phrase library..[@/libs/coroutine/ Coroutine]:]
   * [ticket 10978] remove additional semicolons
   * [ticket 11230] coroutine_error returns dangling exception message pointer
   * [ticket 11234] doesn't compile when used with boost::range::algorithms
   * [ticket 11356] coroutines segfaults with BOOST_USE_SEGMENTED_STACKS
+
+* [phrase library..[@/libs/test/ Boost.Test v3]:]
+  * Major new features
+    * `BOOST_TEST` generic assertion
+    * data driven test cases
+    * test units can now have /attributes/ for finer control over tests behavior (logical grouping, test dependencies, test enabling/disabling)
+    * CLI learned `colour_output` and `list_content`, extended unit test filtering (negation, labels)
+    * refactored and rewritten documentation using quickbook
+  * Addressed issues:
+    * [ticket 2018] [ticket 2450] [ticket 2600] [ticket 2717] [ticket 2759] [ticket 3182] [ticket 3316] [ticket 3392] [ticket 3402] [ticket 3445]
+    * [ticket 3463] [ticket 3542] [ticket 3481] [ticket 3495] [ticket 3592] [ticket 3595] [ticket 3623] [ticket 3664] [ticket 3784] [ticket 3785]
+    * [ticket 3811] [ticket 3834] [ticket 3896] [ticket 3932] [ticket 3938] [ticket 3964] [ticket 3978] [ticket 3979] [ticket 4161] [ticket 4275]
+    * [ticket 4389] [ticket 4434] [ticket 4587] [ticket 4806] [ticket 4911] [ticket 4923] [ticket 4924] [ticket 4982] [ticket 5008] [ticket 5036]
+    * [ticket 5262] [ticket 5374] [ticket 5412] [ticket 5563] [ticket 5582] [ticket 5599] [ticket 5718] [ticket 5729] [ticket 5870] [ticket 5972]
+    * [ticket 6002] [ticket 6071] [ticket 6074] [ticket 6161] [ticket 6766] [ticket 6712] [ticket 6748] [ticket 7046] [ticket 7136] [ticket 7410] [ticket 7894]
+    * [ticket 8201] [ticket 8272] [ticket 8467] [ticket 8862] [ticket 8895] [ticket 9179] [ticket 9272] [ticket 9390] [ticket 9409] [ticket 9537]
+    * [ticket 9539] [ticket 9581] [ticket 9960] [ticket 10318] [ticket 10394] [ticket 10888] [ticket 11054] [ticket 11347] [ticket 11358] [ticket 11359]
+
 
 * /TODO/
 


### PR DESCRIPTION
Hi,

I am not sure about the procedure, I am proposing this PR to update the changelog of the boost.test v3 appearing in the next release of boost (1.59).
BTW, is there any automatic way of pointing to a .qbk in this file? I would like to know if I can point to the changelog of boost.test directly from the release page.

Thanks!
