### PR TITLE
Add note about Hana's postponed release for 1.60.0

### DIFF
--- a/feed/history/boost_1_60_0.qbk
+++ b/feed/history/boost_1_60_0.qbk
@@ -64,6 +64,20 @@
 
 [endsect]
 
+[section News]
+
+[section Release of Hana postponed]
+
+Due to time constraints, the release of [@https://github.com/boostorg/hana Hana]
+will be postponed to a later release of Boost. This will also allow some known
+issues to be addressed properly before releasing the library officially as a
+part of Boost. More information can be found on the
+[@http://article.gmane.org/gmane.comp.lib.boost.devel/263964 mailing list].
+
+[endsect]
+
+[endsect]
+
 [section Compilers Tested]
 
 Boost's primary test compilers are:


### PR DESCRIPTION
I did as suggested on the [mailing list](http://article.gmane.org/gmane.comp.lib.boost.devel/263965), although I think it might be overkill to add a new section just for announcing Hana's postponed release. Maybe it would be better to add a one-liner at the bottom of the __New libraries__ section, which is where people would look first?