### PR TITLE
Change log update for boost.test / boost 1.60

### DIFF
--- a/feed/history/boost_1_60_0.qbk
+++ b/feed/history/boost_1_60_0.qbk
@@ -95,6 +95,18 @@ This change only concerns libraries that use the common Windows API abstraction 
     optional definition of a macro with name `foreach` in this framework.
   * Maintenance fixes.
 
+* [phrase library..[@/libs/test/ Test]:]
+  * Boost.test v3.1 see the
+    '[@/doc/libs/1_60_0/libs/test/doc/html/boost_test/change_log.html Change log]'
+    section for details.
+  * New features
+    * Improved Command Line Interface
+    * Improved dataset API
+  * Bug fixes
+    * [ticket 3384], [ticket 3897], [ticket 6032], [ticket 6859], [ticket 7257]
+    * [ticket 9228], [ticket 10317], [ticket 11279], [ticket 11478]
+    * [ticket 11571], [ticket 11623], [ticket 11624], [ticket 11625]
+
 * [phrase library..[@/libs/thread/ Thread - 4.6.0]:]
   ['New Experimental Features:]
     * [@http://svn.boost.org/trac/boost/ticket/11231 #11231] Allow to set continuation future's destructor behavior to non-blocking


### PR DESCRIPTION
I am not sure about the link `[@/doc/libs/1_60_0/libs/test/doc/html/...` for pointing to the changelog. I adapted the Spirit link for that. The final URL should be `http://www.boost.org/doc/libs/master/libs/test/doc/html/boost_test/change_log.html` .