### PR TITLE
Correct runner's standards.

### DIFF
--- a/feed/history/boost_1_60_0.qbk
+++ b/feed/history/boost_1_60_0.qbk
@@ -332,8 +332,8 @@ Boost's additional test compilers include:
   * Clang: 3.6, 3.7
   * GCC: 4.9.0, 5.2.0
 * FreeBSD:
-  * Clang: 3.4.1, 3.7
-  * GCC: 4.8.5, 5.2.0, 6.0.0
+  * Clang, C++11: 3.4.1, 3.7.0
+  * GCC, C++11: 4.8.5, 5.2.0, 6.0.0
 * QNX:
   * QCC: 4.4.2
 * SunOS:


### PR DESCRIPTION
I believe those lines are describing about my runner which named `Flast-FreeBSD10-*` in regression matrix, and those runners always run under C++11 mode (it is configured via command line, see last section of [Flast-FreeBSD10-clang~gnu++11](http://www.boost.org/development/tests/develop/Flast-FreeBSD10-clang~gnu++11.html)).