### PR TITLE
Add support for storing metadata in a .boost file instead of meta/libraries.json

### DIFF
--- a/development/library_metadata.html
+++ b/development/library_metadata.html
@@ -27,8 +27,9 @@
 
             <div class="section-body">
               <p>A module can contain an optional file which describes the
-              libraries that it contains. This is located at
-              <code>meta/libraries.json</code>. It either contains a single
+              libraries that it contains. This is located at <code>$library/.boost</code>,
+              but <code>$library/meta/libraries.json</code> is also supported
+              for backwards compatibility. It either contains a single
               json object for a single library, or a list or json objects for
               any number of libraries.</p>
 

--- a/site-tools/create-module-metadata.php
+++ b/site-tools/create-module-metadata.php
@@ -62,16 +62,11 @@ function main() {
     foreach ($libraries_by_module as $module => $libraries) {
         $module_libraries = BoostLibraries::from_array($libraries);
         $module_dir = "{$boost_root}/{$git_submodules[$module]['path']}";
-        $meta_dir = "$module_dir/meta";
-        $meta_file = "$module_dir/meta/libraries.json";
+        $meta_file = "$module_dir/.boost";
 
         if (!is_dir($module_dir)) {
             echo "Module '$module' doesn't exist at '$module_dir'\n";
             continue;
-        }
-
-        if (!is_dir($meta_dir)) {
-            mkdir($meta_dir);
         }
 
         file_put_contents($meta_file, $module_libraries->to_json(


### PR DESCRIPTION
This PR contains the changes that should be necessary to implement the proposal [here](http://thread.gmane.org/gmane.comp.lib.boost.devel/264736). This is also related to this pull request: https://github.com/boostorg/bpm/pull/1.

Note that I've never written PHP before and I do not understand how all these scripts relate to each other, so it would be nice to have someone more knowledgeable about the current setup have a look.
