### PR TITLE
[1.61] fix typo geometry function names

### DIFF
--- a/feed/history/boost_1_61_0.qbk
+++ b/feed/history/boost_1_61_0.qbk
@@ -122,9 +122,9 @@
     * [@https://svn.boost.org/trac/boost/ticket/12000 #12000] Uninitialized reference in (unused) constructor of relate's mask_handler.
     * [@https://svn.boost.org/trac/boost/ticket/12106 #12106] Invalid assertion failure in envelope() for non-cartesian very short segments.
   * ['Bugfixes:]
-    * Fix intersects and disjoints for Segment/Box in cartesian coordinate system when Segment is parallel to Box's face.
+    * Fix intersects and disjoint for Segment/Box in cartesian coordinate system when Segment is parallel to Box's face.
     * Fix relation operations for Point/Areal in spherical and geographic coordinate systems for edge cases.
-    * Fix intersect and disjoint for Point/Box and Box/Box in spherical and geographic coordinate systems for some cases.
+    * Fix intersects and disjoint for Point/Box and Box/Box in spherical and geographic coordinate systems for some cases.
     * Fix within and covered_by for Point/Box in spherical and geographic coordinate systems for some cases.
 
 * [phrase library..[@/libs/interprocess/ Interprocess]:]


### PR DESCRIPTION
s/intersect/intersects/
s/disjoints/disjoint/

see reference document: <http://www.boost.org/doc/libs/1_61_0/libs/geometry/doc/html/geometry/matrix.html>