### PR TITLE
Fix function name for Boost.Math release note

### DIFF
--- a/feed/history/boost_1_62_0.qbk
+++ b/feed/history/boost_1_62_0.qbk
@@ -108,7 +108,7 @@
   * New Features:
     * Enabled all the special function code to work correctly with types whose precision can change at runtime: for example type `mpfr_float` from Boost.Multiprecision.
   * Patches:
-    * Fix tgamma_delta_ration for cases where the delta is small compared to the base.
+    * Fix `tgamma_delta_ratio` for cases where the delta is small compared to the base.
     * Fix misc GCC-4.4 test failures.
 
 * [phrase library..[@/libs/phoenix/ Phoenix]:]


### PR DESCRIPTION
s/tgamma_delta_ration/tgamma_delta_ratio/

And I add code qualify.
Related commit is https://github.com/boostorg/math/commit/3891523510a65c202169e168789254f2156f8e45