### PR TITLE
Point runtime_cast docs at the correct url

### DIFF
--- a/feed/history/boost_1_63_0.qbk
+++ b/feed/history/boost_1_63_0.qbk
@@ -66,7 +66,7 @@
   * Removed obsolete bits and pieces
 
 * [phrase library..[@/libs/type_index/ TypeIndex]:]
-  * Added `runtime_cast` to the library as an emulation of `dynamic_cast`. Thanks to Chris Glover for the implementation. See [@/libs/type_index/boost_typeindex_header_reference.html#header.boost.type_index.runtime_cast_hpp runtime_cast reference] for more info.
+  * Added `runtime_cast` to the library as an emulation of `dynamic_cast`. Thanks to Chris Glover for the implementation. See [@/doc/html/boost_typeindex_header_reference.html#header.boost.type_index.runtime_cast_hpp runtime_cast reference] for more info.
   * Internals of the CTTI were made more platform independant, due to change of the `std::size_t` type to `unsigned int`.
 
 * [phrase library..[@/libs/units/ Units]:]


### PR DESCRIPTION
It seems that the runtime_cast URL is incorrect (404), and I think this is the correct one (based on seeing how other doc URLs are specified in other qbk files). But I can't actually test it, so I'm not entirely sure that this is indeed the correct one.