### PR TITLE
1.64.0 : fix typo s/booststamp/bootstamp/

### DIFF
--- a/feed/history/boost_1_64_0.qbk
+++ b/feed/history/boost_1_64_0.qbk
@@ -77,7 +77,7 @@
         * [@https://github.com/boostorg/interprocess/pull/35 GitHub Pull #35 (['"Fixed options for cross-compilation"])].
 
     * New experimental option `BOOST_INTERPROCESS_BOOTSTAMP_IS_SESSION_MANAGER_BASED` from Windows systems.
-      This option derives the unique booststamp used to name the folder where shared memory is placed from registry values associated
+      This option derives the unique bootstamp used to name the folder where shared memory is placed from registry values associated
       with the session manager. This option only works on Vista and later systems and might be more stable than the default version.
 
 * [phrase library..[@/libs/intrusive/ Intrusive]:]


### PR DESCRIPTION
see macro name `BOOST_INTERPROCESS_BOOTSTAMP_IS_SESSION_MANAGER_BASED` and related commit https://github.com/boostorg/interprocess/commit/eedc9b0a4efd428104c5c9ebb61c83704166448e