### PR TITLE
remove unnecessary release note for uuid

### DIFF
--- a/feed/history/boost_1_66_0.qbk
+++ b/feed/history/boost_1_66_0.qbk
@@ -133,9 +133,6 @@
       [@https://svn.boost.org/trac10/ticket/11482 11482]
       [@https://svn.boost.org/trac10/ticket/12253 12253]
       Various deficiencies in `string_generator` were resolved.
-    * [@https://svn.boost.org/trac10/ticket/11483 11483]
-       Invalid `string_generator` inputs now throw
-      `std::invalid_argument` instead of `std::runtime_error`.
     * [@https://svn.boost.org/trac10/ticket/10665 10665]
       `name_generator::operator()` is now const, matching docs.
     * Detail headers were moved into the detail subdirectory.


### PR DESCRIPTION
Depends on submission of https://github.com/boostorg/uuid/pull/54 which makes the release note unnecessary.