### PR TITLE
Fix a couple of typos in the review schedule

### DIFF
--- a/community/review_schedule.html
+++ b/community/review_schedule.html
@@ -62,10 +62,6 @@ http://www.boost.org/development/website_updating.html
 		    
                     <td>Niall Douglas</td>
 		    		    
-                    <td>Charley Bay</td>
-
-                    <td>January 19, 2018 - January 28, 2018</td>
-
                     <td>
                       <ul>
 			<li><a href="https://github.com/ned14/boost-outcome">
@@ -74,6 +70,10 @@ http://www.boost.org/development/website_updating.html
                             Documentation</a></li>
                       </ul>
                     </td>                     
+
+ 		    <td>Charley Bay</td>
+
+                    <td>January 19, 2018 - January 28, 2018</td>
                   </tr>
 
                   <tr>
@@ -167,7 +167,7 @@ http://www.boost.org/development/website_updating.html
 
                   <td>Daniel James</td>
 
-                  <td>December 19, 2018</td>
+                  <td>December 19, 2017</td>
 
                   <td>
                     <a href=


### PR DESCRIPTION
* The `outcome` entry in the table had a couple of columns swapped
* The release date for Boost.1.66.0 was a year off (2018 instead of 2017)