### PR TITLE
[1.67.0] fix Spirit ticket link

### DIFF
--- a/feed/history/boost_1_67_0.qbk
+++ b/feed/history/boost_1_67_0.qbk
@@ -208,7 +208,7 @@
     * Fixed `std::complex` usage without the include ([github spirit 273])
     * Fixed compilation of `match<T &>` ([github spirit 275])
     * Fixed compilation with `BOOST_DISABLE_THREADS` defined ([github spirit 323]) ([ticket 12639])
-    * Increment scanner through iterator policy ([github spirit 336]) #7371
+    * Increment scanner through iterator policy ([github spirit 336]) ([ticket #7371])
     * Removed deprecated in C++17 `std::iterator` usage ([github spirit 345])
 
 * [phrase library..[@/libs/stacktrace/ Stacktrace]:]

--- a/feed/history/boost_1_67_0.qbk
+++ b/feed/history/boost_1_67_0.qbk
@@ -208,7 +208,7 @@
     * Fixed `std::complex` usage without the include ([github spirit 273])
     * Fixed compilation of `match<T &>` ([github spirit 275])
     * Fixed compilation with `BOOST_DISABLE_THREADS` defined ([github spirit 323]) ([ticket 12639])
-    * Increment scanner through iterator policy ([github spirit 336]) ([ticket #7371])
+    /* Increment scanner through iterator policy ([github spirit 336]) ([ticket 7371])
     * Removed deprecated in C++17 `std::iterator` usage ([github spirit 345])
 
 * [phrase library..[@/libs/stacktrace/ Stacktrace]:]

--- a/feed/history/boost_1_67_0.qbk
+++ b/feed/history/boost_1_67_0.qbk
@@ -208,7 +208,7 @@
     * Fixed `std::complex` usage without the include ([github spirit 273])
     * Fixed compilation of `match<T &>` ([github spirit 275])
     * Fixed compilation with `BOOST_DISABLE_THREADS` defined ([github spirit 323]) ([ticket 12639])
-    /* Increment scanner through iterator policy ([github spirit 336]) ([ticket 7371])
+    * Increment scanner through iterator policy ([github spirit 336]) ([ticket 7371])
     * Removed deprecated in C++17 `std::iterator` usage ([github spirit 345])
 
 * [phrase library..[@/libs/stacktrace/ Stacktrace]:]


### PR DESCRIPTION
Now doesn't link to the ticket.
http://www.boost.org/users/history/version_1_67_0.html