### PR TITLE
Add note on #include "furball.hpp" as discouraged

### DIFF
--- a/development/header.html
+++ b/development/header.html
@@ -66,7 +66,9 @@ http://www.boost.org/development/website_updating.html
                 specifies the sub-directory in <tt>#include</tt> directives.
                 Thus the header <a href="#SampleHeader">sample header</a>
                 would be included by <tt>#include
-                &lt;boost/furball.hpp&gt;</tt></li>
+                &lt;boost/furball.hpp&gt;</tt>. (Note, including from current
+                file directory using <tt>#include "furball.hpp"</tt> syntax
+                is discouraged .)</li>
 
                 <li>The preferred ordering for class definitions is public
                 members, protected members, and finally private members.</li>


### PR DESCRIPTION
Spells out already established convention.