### PR TITLE
removed one entry for Boost.Rational

### DIFF
--- a/feed/history/boost_1_68_0.qbk
+++ b/feed/history/boost_1_68_0.qbk
@@ -97,7 +97,6 @@
 
 * [phrase library..[@/libs/rational/ Rational]:]
   * Fixed undefined behavior in normalize() ([github_pr rational 19]).
-  * Added pow method ([github_pr rational 21]).
 
 * [phrase library..[@/libs/uuid/ Uuid]:]
   * [*Breaking change:] sha1 detail namespace header redirection


### PR DESCRIPTION
I assume you are going to alphabetize the release notes by repository before release?  They are not organized properly right now.
