### PR TITLE
removal notice for Boost.Signals (1)

### DIFF
--- a/feed/history/boost_1_68_0.qbk
+++ b/feed/history/boost_1_68_0.qbk
@@ -99,6 +99,11 @@
   * Fixed undefined behavior in normalize() ([github_pr rational 19]).
   * Added pow method ([github_pr rational 21]).
 
+* [phrase library..[@/libs/signals/ Signals]:]
+  * [*Removal Notice:] Boost.Signals will be removed in the next release.
+    Boost.Signals was deprecated in version 1.54.0.  Transition to Boost.Signals2
+    now to avoid disruption.
+
 * [phrase library..[@/libs/uuid/ Uuid]:]
   * [*Breaking change:] sha1 detail namespace header redirection
     for backwards compatibility was removed ([github_pr uuid 69]).


### PR DESCRIPTION
Per the discussion on the mailing list, Boost.Signals was deprecated in 1.54.0 and will be removed in 1.69.0.  Adding a release note in 1.68.0 to warn folks of the upcoming change.  All users can transition to Boost.Signals2 or fork the repository and manage it themselves.