### PR TITLE
Update bug tracker links from Trac GitHub

### DIFF
--- a/community/acknowledgements.html
+++ b/community/acknowledgements.html
@@ -46,9 +46,10 @@ https://www.boost.org/development/website_updating.html
 
                 <dd>
                   <p>Hosting of the Boost mailing lists, our web server, our
-                  <a href="http://svn.boost.org/trac/boost">bug tracker</a>,
-                  is donated by the <a href="http://www.osl.iu.edu/" class=
-                  "external">Open Systems Lab at Indiana University</a>.
+                  <a href="http://svn.boost.org/trac/boost">wiki and old
+                  bug tracker</a>, is donated by the 
+                  <a href="http://www.osl.iu.edu/" class= "external">Open
+                  Systems Lab at Indiana University</a>.
                   Thanks to Andrew Lumsdaine and DongInn Kim for their years
                   of support.</p>
                 </dd>

--- a/community/requests.html
+++ b/community/requests.html
@@ -38,10 +38,10 @@ https://www.boost.org/development/website_updating.html
               policy</a> before you actually post).</p>
 
               <p>You can also try submitting a feature request to our
-              <a href="http://svn.boost.org/trac/boost/newticket">ticket
-              system</a>, but experience has shown that posting to either of
-              the mailing lists is usually a more effective way to get
-              attention of boost developers.</p>
+              <a href="https://github.com/boostorg/">issue tracker</a>
+              on GitHub, but experience has shown that posting to either of
+              the mailing lists is usually a more effective way to get attention
+              of boost developers.</p>
 
               <p>If your proposal has its merits, it's very likely that it
               will generate a constructive discussion that might actually

--- a/development/bugs.html
+++ b/development/bugs.html
@@ -38,36 +38,19 @@ https://www.boost.org/development/website_updating.html
                   "https://github.com/boostorg/boost/wiki/Getting-Started" class=
                   "external">git repositories</a>.</li>
 
-                  <li><a href=
-                  "http://svn.boost.org/trac/boost/search?ticket=on">Search
-                  the bug database</a> to make sure we don't already know
-                  about the bug. If we do, you can add further information to
-                  an existing bug ticket.</li>
-
-                  <li>If you have a userid on the Boost Trac server, please
-                  <a href="http://svn.boost.org/trac/boost/login">log
-                  in</a>.</li>
-
-                  <li><strong>Even if you don't have a userid</strong>, visit
-                  <a href="http://svn.boost.org/trac/boost/prefs">the
-                  preferences page</a> to enter or confirm an email address
-                  at which you can be reached. Most bug reports require some
-                  interaction with the reporter, and if we can't follow up
-                  with you, chances are good that your efforts at reporting
-                  the bug will be wasted.</li>
+                  <li><a href="https://github.com/boostorg/">Search the issues</a>
+                  on GitHub to make sure we don't already know about the bug.
+                  If we do, you can add further information to an existing bug ticket.</li>
 
                   <li>
-                    <p><a href=
-                    "http://svn.boost.org/trac/boost/newticket">Create a new
-                    ticket</a> in the bug tracker.</p>
+                    <p><a href="https://github.com/boostorg/">Create a new issues</a>
+                    in the repository of the particular library of your interest.</p>
 
                     <p>If possible,</p>
 
                     <ul>
-                      <li>Fill out all the fields completely, especially the
-                      &ldquo;component&rdquo; field that identifies the
-                      library. That will help ensure your report is noticed
-                      by the appropriate developers.</li>
+                      <li>Describe the problem carefully, including steps required to
+                      reproduce it by a library maintainers.</li>
 
                       <li>Attach a <em>minimal</em> and <em>complete</em>
                       program that reproduces the problem. Aside from helping

--- a/users/faq.html
+++ b/users/faq.html
@@ -68,11 +68,11 @@ https://www.boost.org/development/website_updating.html
 
               <ol class="faq">
                 <li>Submit patches for new features or bug fixes. Pick any
-                ticket from <a href="http://svn.boost.org/trac/boost">our bug
-                tracking system</a> and get started. If existing library
-                maintainers don't already know your work, this is a good way
-                to become known as someone they can trust to do good
-                work.</li>
+                ticket from <a href="https://github.com/boostorg/">our bug
+                tracking system</a> on GitHub and get started. If existing
+                library maintainers don't already know your work, this is
+                a good way to become known as someone they can trust to
+                do good work.</li>
 
                 <li>Become part of a particular library's community, and
                 become known to the library maintainer(s) by participating in


### PR DESCRIPTION
This is an initial attempt to re-direct bugs and patches from the Trac to the GitHub.
This follows the discussion on the mailing list and making the Trac read-only:
* https://lists.boost.org/Archives/boost/2018/07/242643.php