### PR TITLE
Add guidelines on how to maintain copyright messages

### DIFF
--- a/users/license.html
+++ b/users/license.html
@@ -225,6 +225,17 @@ https://www.boost.org/development/website_updating.html
               (<code>../LICENSE_1_0.txt</code>,
               <code>../../LICENSE_1_0.txt</code> etc.)</span></p>
 
+              <p class="faq"><span class="faq-question">How should Boost
+              programmers maintain the copyright messages?</span>
+              <span class="faq-answer">Copyright is only claimed for changes
+              meeting a certain threshold of originality. Therefore, the copyright
+              message only covers expressions of creativity. It is up to authors of
+              changes to add themselves to the copyright message if they so decide.
+              Typically, new claimant is added when someone takes over maintenance
+              of a library or new version of an existing library is developed.
+              In principle, do not ever remove previous copyright claims -
+              just add new claims and/or claimants.</span></p>
+
               <p class="faq"><span class="faq-question">How is the Boost
               license different from the <a href=
               "https://opensource.org/licenses/gpl-license.php" class=


### PR DESCRIPTION
This is based on conclusions following various discussions on the Boost
mailing list, which have been summarised in the thread
"Guidelines on copyright notice maintenance"
https://lists.boost.org/Archives/boost/2018/07/242396.php

/cc @pabristow 