### PR TITLE
Fix tested compiler names: Clang -> Apple Clang

### DIFF
--- a/feed/history/boost_1_68_0.qbk
+++ b/feed/history/boost_1_68_0.qbk
@@ -290,11 +290,11 @@ Boost's additional test compilers include:
   * GCC, C++17: 7.3.0, 8.0.1
   * Intel, C++14: 18.0
 * OS X:
-  * Clang: 9.0.0, 9.1.0
-  * Clang, C++11: 9.0.0, 9.1.0
-  * Clang, C++14: 9.0.0, 9.1.0
-  * Clang, C++17: 9.1.0
-  * Clang, C++1z: 9.0.0
+  * Apple Clang: 9.0.0, 9.1.0
+  * Apple Clang, C++11: 9.0.0, 9.1.0
+  * Apple Clang, C++14: 9.0.0, 9.1.0
+  * Apple Clang, C++17: 9.1.0
+  * Apple Clang, C++1z: 9.0.0
 * Windows:
   * GCC: 3.4.5, 4.1.2, 4.2.4, 4.3.3, 4.4.0, 4.5.4
   * GCC, C++0x: 4.6.4

--- a/feed/history/boost_1_68_0.qbk
+++ b/feed/history/boost_1_68_0.qbk
@@ -257,11 +257,11 @@ Boost's primary test compilers are:
   * GCC, C++17: 7.3.0, 8.0.1
   * Intel, C++14: 18.0
 * OS X:
-  * Clang: 9.0.0, 9.1.0
-  * Clang, C++11: 9.0.0, 9.1.0
-  * Clang, C++14: 9.0.0, 9.1.0
-  * Clang, C++17: 9.1.0
-  * Clang, C++1z: 9.0.0
+  * Apple Clang: 9.0.0, 9.1.0
+  * Apple Clang, C++11: 9.0.0, 9.1.0
+  * Apple Clang, C++14: 9.0.0, 9.1.0
+  * Apple Clang, C++17: 9.1.0
+  * Apple Clang, C++1z: 9.0.0
 * Windows:
   * GCC: 3.4.5, 4.1.2, 4.2.4, 4.3.3, 4.4.0, 4.5.4
   * GCC, C++0x: 4.6.4

--- a/feed/history/boost_1_69_0.qbk
+++ b/feed/history/boost_1_69_0.qbk
@@ -344,11 +344,11 @@ Boost's primary test compilers are:
   * GCC, C++17: 7.3.0, 8.0.1
   * Intel, C++14: 18.0
 * OS X:
-  * Clang: 9.0.0, 9.1.0
-  * Clang, C++11: 9.0.0, 9.1.0
-  * Clang, C++14: 9.0.0, 9.1.0
-  * Clang, C++17: 9.1.0
-  * Clang, C++1z: 9.0.0
+  * Apple Clang: 9.0.0, 9.1.0
+  * Apple Clang, C++11: 9.0.0, 9.1.0
+  * Apple Clang, C++14: 9.0.0, 9.1.0
+  * Apple Clang, C++17: 9.1.0
+  * Apple Clang, C++1z: 9.0.0
 * Windows:
   * GCC: 3.4.5, 4.1.2, 4.2.4, 4.3.3, 4.4.0, 4.5.4
   * GCC, C++0x: 4.6.4

--- a/feed/history/boost_1_69_0.qbk
+++ b/feed/history/boost_1_69_0.qbk
@@ -344,11 +344,12 @@ Boost's primary test compilers are:
   * GCC, C++17: 7.3.0, 8.0.1
   * Intel, C++14: 18.0
 * OS X:
-  * Apple Clang: 9.0.0, 9.1.0
-  * Apple Clang, C++11: 9.0.0, 9.1.0
-  * Apple Clang, C++14: 9.0.0, 9.1.0
-  * Apple Clang, C++17: 9.1.0
+  * Apple Clang: 9.0.0, 9.1.0, 10.0.0
+  * Apple Clang, C++11: 9.0.0, 9.1.0, 10.0.0
+  * Apple Clang, C++14: 9.0.0, 9.1.0, 10.0.0
+  * Apple Clang, C++17: 9.1.0, 10.0.0
   * Apple Clang, C++1z: 9.0.0
+  * Apple Clang, C++2a: 10.0.0
 * Windows:
   * GCC: 3.4.5, 4.1.2, 4.2.4, 4.3.3, 4.4.0, 4.5.4
   * GCC, C++0x: 4.6.4
@@ -377,11 +378,12 @@ Boost's additional test compilers include:
   * GCC, C++17: 7.3.0, 8.0.1
   * Intel, C++14: 18.0
 * OS X:
-  * Clang: 9.0.0, 9.1.0
-  * Clang, C++11: 9.0.0, 9.1.0
-  * Clang, C++14: 9.0.0, 9.1.0
-  * Clang, C++17: 9.1.0
-  * Clang, C++1z: 9.0.0
+  * Apple Clang: 9.0.0, 9.1.0, 10.0.0
+  * Apple Clang, C++11: 9.0.0, 9.1.0, 10.0.0
+  * Apple Clang, C++14: 9.0.0, 9.1.0, 10.0.0
+  * Apple Clang, C++17: 9.1.0, 10.0.0
+  * Apple Clang, C++1z: 9.0.0
+  * Apple Clang, C++2a: 10.0.0
 * Windows:
   * GCC: 3.4.5, 4.1.2, 4.2.4, 4.3.3, 4.4.0, 4.5.4
   * GCC, C++0x: 4.6.4


### PR DESCRIPTION
LLVM Project's Clang and Apple Clang use different version numbering system. On OS X, tested compilers are Apple Clang but not (LLVM Project's) Clang.