### PR TITLE
Allow LICENSE file per a library repository

### DIFF
--- a/development/requirements.html
+++ b/development/requirements.html
@@ -632,10 +632,10 @@ alias boostdoc ;
                 preferred form is indicated in the <a href=
                 "../users/license.html">license information</a> page</li>
 
-                <li>Note that developers should not provide a copy of
-                <code>LICENSE_1_0.txt</code> with their libraries: Boost
-                distributions already include a copy in the Boost root
-                directory.</li>
+                <li>Note that developers are allowed to provide a copy of
+                the license text in <code>LICENSE_1_0.txt</code>,
+                <code>LICENSE.txt</code> or <code>LICENSE</code>
+                file within repositories of their libraries.</li>
 
                 <li>A comment line referencing your library on the Boost web
                 site. For example:

--- a/users/license.html
+++ b/users/license.html
@@ -219,12 +219,6 @@ https://www.boost.org/development/website_updating.html
               linked to. Refer to the HTML source code of this page in case
               of doubt.</span></p>
 
-              <p><span class="faq-answer">Note that the location of the local
-              LICENSE_1_0.txt needs to be indicated relatively to the
-              position of your documentation file
-              (<code>../LICENSE_1_0.txt</code>,
-              <code>../../LICENSE_1_0.txt</code> etc.)</span></p>
-
               <p class="faq"><span class="faq-question">How should Boost
               programmers maintain the copyright messages?</span>
               <span class="faq-answer">Copyright is only claimed for changes


### PR DESCRIPTION
The requirement was established in the pre-GitHub era when Boost codebase was hosted in single the repository.

Besides, there are around thirty libraries already 'breaking' the old guideline.

-----

On https://cpplang.slack.com/channels/boost @pdimov suggested to include `LICENSE.md` across repositories of the whole organization. Although I think the idea is valid it may require some more changes (with general agreement), eg.:

- Allow https://www.boost.org/LICENSE.md as equivalent of https://www.boost.org/LICENSE_1_0.txt
- Update the website to mention `LICENSE.md`

Neither of those is included in this PR.

