### PR TITLE
Replaces two broken to books with doi permalinks.

### DIFF
--- a/community/error_handling.html
+++ b/community/error_handling.html
@@ -38,7 +38,7 @@ https://www.boost.org/development/website_updating.html
                 <p><a href="/community/exception_safety.html">D. Abrahams:
                 ``Exception Safety in Generic Components''</a>, originally
                 published in <a href=
-                "http://www.springer.de/cgi-bin/search_book.pl?isbn=3-540-41090-2">
+                "https://doi.org/10.1007/3-540-39953-4">
                 M. Jazayeri, R. Loos, D. Musser (eds.): Generic Programming,
                 Proc. of a Dagstuhl Seminar, Lecture Notes on Computer
                 Science. Volume. 1766</a></p>

--- a/users/bibliography.html
+++ b/users/bibliography.html
@@ -773,8 +773,8 @@ https://www.boost.org/development/website_updating.html
                 <dd><a name="Kormanyos13" id="Kormanyos13"></a>[Kormanyos13]</dd>
                 <dt>Christopher Kormanyos,
 				<cite>Real-Time C++: Efficient Object-Oriented and Template Microcontroller Programming</cite>.
-			    <a href="http://www.springer.com/computer/communication+networks/book/978-3-642-34687-3"
-				class="external">http://www.springer.com/computer/communication+networks/book/978-3-642-34687-3</a><br>
+			    <a href="https://doi.org/10.1007/978-3-662-56718-0"
+				class="external">https://doi.org/10.1007/978-3-662-56718-0</a><br>
 
                 Uses C++11 including lambdas, templates, metatemplate programming for efficient
 				programming for microcontrollers including use of Boost.Math, Boost.Regex, Boost.Multiprecision


### PR DESCRIPTION
The two links to the Springer website that this commit replaces are broken. The doi links point to the intended resource (if I didn't make a mistake) and are intended to resolve correctly even if the Springer website should change again (see https://www.doi.org/ ). 