### PR TITLE
Update the example for release notes

### DIFF
--- a/feed/history/boost_1_71_0.qbk
+++ b/feed/history/boost_1_71_0.qbk
@@ -29,8 +29,15 @@
 
 [/ Example:
 * [phrase library..[@/libs/interprocess/ Interprocess]:]
-  * Added anonymous shared memory for UNIX systems.
-  * `shared_ptr` is movable and supports aliasing ([ticket 1234]).
+  * See examples below (use better descriptions than these!):
+  * This shows how to reference an older Trac issue ([ticket 1234]).
+  * This shows how to reference a GitHub issue [github interprocess 1234].
+  * This shows how to reference a GitHub pull request [github_pr interprocess 1234].
+  * [@https://www.google.com [*link to something]]
+  * [*bold text]
+  * [role green [*bold green text]]
+  * \u26a1 use unicode
+  * Keep the list of libraries in alphabetical order please.
 ]
 
 * /TODO/

--- a/feed/history/boost_1_71_0.qbk
+++ b/feed/history/boost_1_71_0.qbk
@@ -14,6 +14,11 @@
 
 [import ext.qbk]
 
+[/
+Formatting reference: https://www.boost.org/doc/tools/quickbook/
+Please keep the list of libraries sorted in lexicographical order.
+]
+
 [section New Libraries]
 
 [/ Example:
@@ -29,15 +34,10 @@
 
 [/ Example:
 * [phrase library..[@/libs/interprocess/ Interprocess]:]
-  * See examples below (use better descriptions than these!):
-  * This shows how to reference an older Trac issue ([ticket 1234]).
-  * This shows how to reference a GitHub issue [github interprocess 1234].
-  * This shows how to reference a GitHub pull request [github_pr interprocess 1234].
-  * [@https://www.google.com [*link to something]]
-  * [*bold text]
-  * [role green [*bold green text]]
-  * \u26a1 use unicode
-  * Keep the list of libraries in alphabetical order please.
+  * Added anonymous shared memory for UNIX systems.
+  * Move semantics for shared objects ([ticket 1932]).
+  * Conform to `std::pointer_traits` requirements ([github_pr interprocess 32])
+  * Fixed `named_condition_any` fails to notify ([github interprocess 62])
 ]
 
 * /TODO/

--- a/feed/templates/boost_x_xx_x.qbk
+++ b/feed/templates/boost_x_xx_x.qbk
@@ -29,8 +29,15 @@
 
 [/ Example:
 * [phrase library..[@/libs/interprocess/ Interprocess]:]
-  * Added anonymous shared memory for UNIX systems.
-  * `shared_ptr` is movable and supports aliasing ([ticket 1234]).
+  * See examples below (use better descriptions than these!):
+  * This shows how to reference an older Trac issue ([ticket 1234]).
+  * This shows how to reference a GitHub issue [github interprocess 1234].
+  * This shows how to reference a GitHub pull request [github_pr interprocess 1234].
+  * [@https://www.google.com [*link to something]]
+  * [*bold text]
+  * [role green [*bold green text]]
+  * \u26a1 use unicode
+  * Keep the list of libraries in alphabetical order please.
 ]
 
 * /TODO/

--- a/feed/templates/boost_x_xx_x.qbk
+++ b/feed/templates/boost_x_xx_x.qbk
@@ -14,6 +14,11 @@
 
 [import ext.qbk]
 
+[/
+Formatting reference: https://www.boost.org/doc/tools/quickbook/
+Please keep the list of libraries sorted in lexicographical order.
+]
+
 [section New Libraries]
 
 [/ Example:
@@ -29,15 +34,10 @@
 
 [/ Example:
 * [phrase library..[@/libs/interprocess/ Interprocess]:]
-  * See examples below (use better descriptions than these!):
-  * This shows how to reference an older Trac issue ([ticket 1234]).
-  * This shows how to reference a GitHub issue [github interprocess 1234].
-  * This shows how to reference a GitHub pull request [github_pr interprocess 1234].
-  * [@https://www.google.com [*link to something]]
-  * [*bold text]
-  * [role green [*bold green text]]
-  * \u26a1 use unicode
-  * Keep the list of libraries in alphabetical order please.
+  * Added anonymous shared memory for UNIX systems.
+  * Move semantics for shared objects ([ticket 1932]).
+  * Conform to `std::pointer_traits` requirements ([github_pr interprocess 32])
+  * Fixed `named_condition_any` fails to notify ([github interprocess 62])
 ]
 
 * /TODO/


### PR DESCRIPTION
Added examples for github, github pull requests, links, bolding, unicode, etc.
This wasn't carried over from the 1_70_0 feed history.  Why?