### PR TITLE
Boost.Test change log for 1.71

### DIFF
--- a/feed/history/boost_1_70_0.qbk
+++ b/feed/history/boost_1_70_0.qbk
@@ -284,7 +284,7 @@ process.
 
 * [phrase library..[@/libs/test/ Test]:]
   * Boost.test v3.10 see the
-    [@libs/test/doc/html/boost_test/change_log.html Changes log]
+    [@/libs/test/doc/html/boost_test/change_log.html Changes log]
     for more details.
   * Breaking changes:
     * Boost.Test `minimal.hpp` is now showing a deprecation warning,

--- a/feed/history/boost_1_71_0.qbk
+++ b/feed/history/boost_1_71_0.qbk
@@ -304,6 +304,22 @@ Please keep the list of libraries sorted in lexicographical order.
   * Fixed output of long strings from `name()` and `source_location()` on MSVC [github stacktrace 78].
   * Maintenance work.
 
+* [phrase library..[@/libs/test/ Test]:]
+  * Boost.test v3.11 see the
+    [@libs/test/doc/html/boost_test/change_log.html Changes log]
+    for more details.
+  
+  * Breaking changes:
+    * Boost.Test shows deprecation warnings if some very old headers as deprecated. If you encounter
+      such warnings, please follow the indications: those headers will be removed in a future release.
+  
+  * New feature:
+    * Now `BOOST_TEST` can be used to compare abstract types
+
+  * Bug fixes and pull requests:
+    * GitHub Issues: [github test 209], [github test 218]
+    * GitHub Pull Requests: [github_pr test 219], [github_pr test 224]
+
 * [phrase library..[@/libs/utility/ Utility]:]
   * Implemented function template `ostream_string` in `boost/utility/ostream_string.hpp` to optimally write any kind of string content to an output stream. It satisfies the requirements of \[ostream.formatted.reqmts\]. (Glen Fernandes)
   * Optimized the stream output operators of `basic_string_view` and `basic_string_ref` to write directly to the `rdbuf` stream buffer.  (Glen Fernandes)


### PR DESCRIPTION
Hi,

This is the change log for Boost.Test. It contains also a little link fix for the release notes of 1.70, I do not know if those would be deployed/backported. If you want me to remove that fix, please let me know.