### PR TITLE
Replace dead link with web.archive.org-link

### DIFF
--- a/users/license.html
+++ b/users/license.html
@@ -337,14 +337,12 @@ https://www.boost.org/development/website_updating.html
 
               <p>Dave Abrahams led the Boost effort to develop better
               licensing. The legal team was led by <a href=
-              "http://cyber.law.harvard.edu/people/cabell/" class=
+              "https://cyber.harvard.edu/people/dcabell" class=
               "external">Diane Cabell</a>, Director, Clinical Programs,
-              <a href="http://cyber.law.harvard.edu/" class=
+              <a href="https://cyber.harvard.edu/" class=
               "external">Berkman Center for Internet &amp; Society</a>,
-              Harvard Law School. <a href=
-              "http://www.nixonpeabody.com/attorneys_detail1.asp?ID=121"
-              class="external">Devin Smith</a>, attorney, <a href=
-              "http://www.nixonpeabody.com/" class="external">Nixon Peabody
+              Harvard Law School. Devin Smith, attorney, <a href=
+              "https://www.nixonpeabody.com/" class="external">Nixon Peabody
               LLP</a>, wrote the Boost License. Eva Chan, Harvard Law School,
               contributed analysis of Boost issues and drafts of various
               legal documents. Boost members reviewed drafts of the license.


### PR DESCRIPTION
The link to Mr. Smith's site at nixonpeabody.com is dead since 2006, but there is still a copy at web.archive.org. While that provides more information than a 404 page, apparently the person does not work at Nixon Peabody anymore, so maybe removing the link entirely is also a sensible option.

The addresses of the people page for Diane Cabell and the Berkman Center for Internet & Society have also changed.