### PR TITLE
Update GIL release notes for Boost 1.72.0

### DIFF
--- a/feed/history/boost_1_72_0.qbk
+++ b/feed/history/boost_1_72_0.qbk
@@ -125,9 +125,10 @@ Please keep the list of libraries sorted in lexicographical order.
   * Changed
     * Move all tests, core features and extensions, inside `test/` directory ([@https://github.com/boostorg/gil/pull/302 PR #302]).
   * Removed
-    * Dropped support for GCC <= 4.8 ([@https://github.com/boostorg/gil/pull/296 PR #296]).
     * Replace Boost.MPL with Boost.MP11 ([@https://github.com/boostorg/gil/pull/274 PR #274]).
     * Removed use of Boost.TypeTraits ([@https://github.com/boostorg/gil/pull/274 PR #274]).
+    * Dropped support for GCC <= 4.8 ([@https://github.com/boostorg/gil/pull/296 PR #296]).
+    * Remove `include/boost/gil/version.hpp` file as unused ([@https://github.com/boostorg/gil/pull/403 PR #403]).
   * Fixed
     * Undetermined value of default-initialized channel and pixel objects ([@https://github.com/boostorg/gil/pull/273 PR #273]).
     * Undefined behaviour due to `std::is_trivially_default_constructible` specializations ([@https://github.com/boostorg/gil/pull/284 PR #284]).


### PR DESCRIPTION
This updates notes added in #459 with changes that arrived to GIL `master` in post-beta merge following green light from @mjcaisse  in https://lists.boost.org/Archives/boost/2019/11/247433.php

/cc @stefanseefeld 