### PR TITLE
Remove broken link to Google+ community

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -52,9 +52,7 @@ https://www.boost.org/development/website_updating.html
               <p>If you are looking for more lively interaction with the
               Boost community there are also some <a href="irc.html">internet
               relay chat</a> channels that users and developers like to hang
-              out in. You can also join
-              the <a href="https://plus.google.com/communities/106814259809358442744">Google+
-              community</a>.</p>
+              out in.
 
               <p>Below is a community maintained calendar of Boost related
               events. Mostly this includes development of the release. Note


### PR DESCRIPTION
Remove broken link to Google+ community which is no longer existent (HTTP 404).