### PR TITLE
Deleted information about #boost-soc on irc.

### DIFF
--- a/community/irc.html
+++ b/community/irc.html
@@ -61,15 +61,7 @@ https://www.boost.org/development/website_updating.html
                 "irc://freenode/boost">Connect</a></li>
               </ul>
 
-              <h2>#boost-soc</h2>
-
-              <p>When in session students and mentors participating in the
-              Google Summer of Code program take their discussions here.</p>
-
-              <ul class="menu">
-                <li><a class="external" href=
-                "irc://freenode/boost-soc">Connect</a></li>
-              </ul>
+             
 
               <h2>##c++</h2>
 


### PR DESCRIPTION
There is no such channel on irc freenode.