### PR TITLE
Replace URLs to GIL pull requests with github_pr template

### DIFF
--- a/feed/history/boost_1_72_0.qbk
+++ b/feed/history/boost_1_72_0.qbk
@@ -136,34 +136,34 @@ process.
 
 * [phrase library..[@/libs/gil/ GIL]:]
   * Added
-    * GSoC 2019: Lanczos resampling for image down scaling ([@https://github.com/boostorg/gil/pull/309 PR #309]).
-    * GSoC 2019: Methods for binary thresholding, inverted binary thresholding and truncation thresholding ([@https://github.com/boostorg/gil/pull/313 PR #313]).
-    * GSoC 2019: Otsu thresholding method ([@https://github.com/boostorg/gil/pull/314 PR #314]).
-    * GSoC 2019: Adaptive thresholding using mean or gaussian-weighted sum of the neighbourhood area ([@https://github.com/boostorg/gil/pull/315 PR #315]).
-    * GSoC 2019: Harris response calculation (corner detector without non-maximum filtering) ([@https://github.com/boostorg/gil/pull/350 PR #350]).
-    * GSoC 2019: Hessian corner detector ([@https://github.com/boostorg/gil/pull/364 PR #364]).
-    * GSoC 2019: Types for defining 2D kernel, `kernel_2d` and `kernel_2d_fixed`, in Numeric extension ([@https://github.com/boostorg/gil/pull/361 PR #361]).
-    * GSoC 2019: Implementation of 2D convolution as new function `convolve_2d` ([@https://github.com/boostorg/gil/pull/367 PR #367]).
-    * GSoC 2019: Box filtering using the average filter ([@https://github.com/boostorg/gil/pull/383 PR #383]).
-    * GSoC 2019: Blur function based on normalized mean filter ([@https://github.com/boostorg/gil/pull/383 PR #383]).
-    * GSoC 2019: Sobel and Scharr operators ([@https://github.com/boostorg/gil/pull/392 PR #392]).
-    * GSoC 2019: Median filter to remove noise from image ([@https://github.com/boostorg/gil/pull/393 PR #393]).
+    * GSoC 2019: Lanczos resampling for image down scaling ([github_pr gil 309]).
+    * GSoC 2019: Methods for binary thresholding, inverted binary thresholding and truncation thresholding ([github_pr gil 313]).
+    * GSoC 2019: Otsu thresholding method ([github_pr gil 314]).
+    * GSoC 2019: Adaptive thresholding using mean or gaussian-weighted sum of the neighbourhood area ([github_pr gil 315]).
+    * GSoC 2019: Harris response calculation (corner detector without non-maximum filtering) ([github_pr gil 350]).
+    * GSoC 2019: Hessian corner detector ([github_pr gil 364]).
+    * GSoC 2019: Types for defining 2D kernel, `kernel_2d` and `kernel_2d_fixed`, in Numeric extension ([github_pr gil 361]).
+    * GSoC 2019: Implementation of 2D convolution as new function `convolve_2d` ([github_pr gil 367]).
+    * GSoC 2019: Box filtering using the average filter ([github_pr gil 383]).
+    * GSoC 2019: Blur function based on normalized mean filter ([github_pr gil 383]).
+    * GSoC 2019: Sobel and Scharr operators ([github_pr gil 392]).
+    * GSoC 2019: Median filter to remove noise from image ([github_pr gil 393]).
     * Continued adding new test cases and significantly improved overall test coverage.
-    * Documented purpose of `cached_location_t` ([@https://github.com/boostorg/gil/pull/287 PR #287]).
-    * Function `convolve_1d` in Numeric extension for convenient use of `convolve_rows` and `convolve_cols` ([@https://github.com/boostorg/gil/pull/347 PR #347]) and [@https://github.com/boostorg/gil/pull/367 PR #367]).
-    * Function `extend_boundary` in Numeric extension to perform image boundary extension ([@https://github.com/boostorg/gil/pull/386 PR #386]).
-    * Project release notes maintained in Markdown file `RELEASES.md` ([@https://github.com/boostorg/gil/pull/404 PR #404]).
+    * Documented purpose of `cached_location_t` ([github_pr gil 287]).
+    * Function `convolve_1d` in Numeric extension for convenient use of `convolve_rows` and `convolve_cols` ([github_pr gil 347]) and [github_pr gil 367]).
+    * Function `extend_boundary` in Numeric extension to perform image boundary extension ([github_pr gil 386]).
+    * Project release notes maintained in Markdown file `RELEASES.md` ([github_pr gil 404]).
   * Changed
-    * Move all tests, core features and extensions, inside `test/` directory ([@https://github.com/boostorg/gil/pull/302 PR #302]).
+    * Move all tests, core features and extensions, inside `test/` directory ([github_pr gil 302]).
   * Removed
-    * Replace Boost.MPL with Boost.MP11 ([@https://github.com/boostorg/gil/pull/274 PR #274]).
-    * Removed use of Boost.TypeTraits ([@https://github.com/boostorg/gil/pull/274 PR #274]).
-    * Dropped support for GCC <= 4.8 ([@https://github.com/boostorg/gil/pull/296 PR #296]).
-    * Remove `include/boost/gil/version.hpp` file as unused ([@https://github.com/boostorg/gil/pull/403 PR #403]).
+    * Replace Boost.MPL with Boost.MP11 ([github_pr gil 274]).
+    * Removed use of Boost.TypeTraits ([github_pr gil 274]).
+    * Dropped support for GCC <= 4.8 ([github_pr gil 296]).
+    * Remove `include/boost/gil/version.hpp` file as unused ([github_pr gil 403]).
   * Fixed
-    * Undetermined value of default-initialized channel and pixel objects ([@https://github.com/boostorg/gil/pull/273 PR #273]).
-    * Undefined behaviour due to `std::is_trivially_default_constructible` specializations ([@https://github.com/boostorg/gil/pull/284 PR #284]).
-    * Crash when reading PNG files with an invalid header ([@https://github.com/boostorg/gil/pull/385 PR #385]).
+    * Undetermined value of default-initialized channel and pixel objects ([github_pr gil 273]).
+    * Undefined behaviour due to `std::is_trivially_default_constructible` specializations ([github_pr gil 284]).
+    * Crash when reading PNG files with an invalid header ([github_pr gil 385]).
     * Applied the Rule of Three for numerous types.
     * Removed uses of deprecated implicit definition of defaulted copy assignment operator or copy constructor.
 


### PR DESCRIPTION
It's just refactoring of GIL release notes.

Apparently, I'm late catcher wrt the quickbook cool stuff :)