### PR TITLE
Add GIL release notes for Boost 1.73.0

### DIFF
--- a/feed/history/boost_1_73_0.qbk
+++ b/feed/history/boost_1_73_0.qbk
@@ -80,6 +80,24 @@ Please keep the list of libraries sorted in lexicographical order.
 * [phrase library..[@/libs/flyweight/index.html Flyweight]:]
   * Maintenance work.
 
+* [phrase library..[@/libs/gil/ GIL]:]
+  * Added
+    * New member function `size()` in `any_image_view` class ([github_pr gil 456]).
+  * Changed
+    * Replace Boost.Test with Boost.LightweightTest as the only test framework used in GIL ([github_pr gil 459]) and ([github_pr gil 464]). This also restructured the `test/extension/io/` sub-tree and targets in related `Jamfile`-s.
+    * Removed remaining uses of Boost.MPL ([github_pr gil 459]).
+    * Renamed all macros using `BOOST_GIL_` prefix ([github_pr gil 411]).
+    * Renamed all CMake configuration options using `BOOST_GIL_` prefix ([github_pr gil 419]).
+  * Changed
+    * Removed `extension/dynamic_image/reduce.hpp` as unused and possibly unfinished ([github_pr gil 466]). An implementation attempt of techniques described in the paper [Efficient Run-Time Dispatching in Generic Programming with Minimal Code Bloat](http://lubomir.org/academic/MinimizingCodeBloat.pdf) by Lubomir Bourdev, Jaakko Jarvi.
+    * Removed direct dependency on Boost.MPL, Boost.System and Boost.Test.
+    * Started removing public macros for compile-time configuration of I/O extension tests, i.e. `BOOST_GIL_IO_TEST_ALLOW_READING_IMAGES` and `BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES`. Instead, if a test target is built, it builds all its test cases unconditionally.
+  * Fixed
+    * Avoid `longjmp` interaction during destruction of I/O extension objects ([github_pr gil 433]).
+    * Fixed missing alignment default value in constructor of `image` class ([github_pr gil 429]).
+    * Fixed segmentation fault when reading corrupted PNG file ([github_pr gil 414]).
+    * Fixed illegal initialization of return values in the old IOv1 interface of I/O extension ([github_pr gil 409]).
+
 * [phrase library..[@/libs/lexical_cast/ LexicalCast]:]
   * Maintenance work, including CI hardening and better workarounds for broken standard libraries (thanks to Nikita Kniazev [github lexical_cast 32], [github lexical_cast 33]).
 


### PR DESCRIPTION
The GIL `develop` branch has now been merged to `master` and includes all the changes listed here.