### PR TITLE
Fix link syntax in GIL release notes

### DIFF
--- a/feed/history/boost_1_73_0.qbk
+++ b/feed/history/boost_1_73_0.qbk
@@ -167,7 +167,7 @@ Please keep the list of libraries sorted in lexicographical order.
     * Renamed all macros using `BOOST_GIL_` prefix ([github_pr gil 411]).
     * Renamed all CMake configuration options using `BOOST_GIL_` prefix ([github_pr gil 419]).
   * Changed
-    * Removed `extension/dynamic_image/reduce.hpp` as unused and possibly unfinished ([github_pr gil 466]). An implementation attempt of techniques described in the paper [Efficient Run-Time Dispatching in Generic Programming with Minimal Code Bloat](http://lubomir.org/academic/MinimizingCodeBloat.pdf) by Lubomir Bourdev, Jaakko Jarvi.
+    * Removed `extension/dynamic_image/reduce.hpp` as unused and possibly unfinished ([github_pr gil 466]). An implementation attempt of techniques described in the paper [@http://lubomir.org/academic/MinimizingCodeBloat.pdf Efficient Run-Time Dispatching in Generic Programming with Minimal Code Bloat] by Lubomir Bourdev, Jaakko Jarvi.
     * Removed direct dependency on Boost.MPL, Boost.System and Boost.Test.
     * Started removing public macros for compile-time configuration of I/O extension tests, i.e. `BOOST_GIL_IO_TEST_ALLOW_READING_IMAGES` and `BOOST_GIL_IO_TEST_ALLOW_WRITING_IMAGES`. Instead, if a test target is built, it builds all its test cases unconditionally.
   * Fixed


### PR DESCRIPTION
Missing Markdown to Quickbook correction.