### PR TITLE
Add explicit note that review manager can also review the library

### DIFF
--- a/community/reviews.html
+++ b/community/reviews.html
@@ -235,8 +235,7 @@ https://www.boost.org/development/website_updating.html
                 review.
                 </li>
 
-                <li>Urges people to do reviews if they aren't forthcoming.
-                Review manager is also allowed to review the library.</li>
+                <li>Urges people to do reviews if they aren't forthcoming.</li>
 
                 <li>Follows review discussions regarding the library,
                 moderating or answering questions as needed.</li>
@@ -264,6 +263,14 @@ https://www.boost.org/development/website_updating.html
 
               <p>In other words, it is the Review Manager's responsibility to
               make sure the review process works smoothly.</p>
+
+              <p>Although the review manager is also allowed to review the library,
+              they are expected to serve the interests of the Boost users.
+              Since the review manager may have a (strong) opinion about the library,
+              it is recommended as a matter of principle they do not share their opinion
+              until the very end of the review. Possibly, until the summary of reviews.
+              The review manager will make the final choice and announcing an opinion early
+              in the process could negatively affect the review process.</p>
 
               <h2><a name="Submitters" id="Submitters"></a>Notes for Library
               Submitters</h2>


### PR DESCRIPTION
Following [my question on Slack](https://app.slack.com/client/T21Q22G66/C27KZLB0X/thread/C27KZLB0X-1598027714.261000), I'd like to get this aspect of a library review explicitly clarified.

Apparently, there have been such precedents in the past; it's allowed.

