### PR TITLE
Add clarification on acceptance of review manager by library submitter

### DIFF
--- a/community/reviews.html
+++ b/community/reviews.html
@@ -182,7 +182,8 @@ https://www.boost.org/development/website_updating.html
               active boost member not connected with the library submission
               must volunteer to be the "Review Manager" for the library.
               Members may contact a library author on- or off-list to express
-              interest in managing the review.</p>
+              interest in managing the review. The library author has to accept
+              a person as a review manager.</p>
 
               <p>The Review Manager:</p>
 
@@ -271,7 +272,11 @@ https://www.boost.org/development/website_updating.html
               <p>See <a href="/development/submissions.html">Submission
               Process</a> for a description of the steps a library developer
               goes through to get a library accepted by Boost.</p>
-
+              
+              <p>First, the library author should accept a review manager.
+              If they feel, for whatever reason, a candidate for a review manager
+              is not competent or fair, they should not accept such candidate.</p>
+  
               <p>A proposed library should remain stable during the review
               period; it will just confuse and irritate reviewers if there
               are numerous changes. It is, however, useful to upload fixes
@@ -322,9 +327,10 @@ https://www.boost.org/development/website_updating.html
                 <li>When a formal review is requested for a library:
 
                   <ul>
-                    <li>Approve the review manager based on their
-                    participation in the Boost community, including the
-                    mailing list, previous reviews, and other forums.</li>
+                    <li>Approve the review manager based on initial acceptance
+                    by the library submitter, their participation in the Boost
+                    community, including the mailing list, previous reviews,
+                    and other forums.</li>
 
                     <li>Suggest a schedule, after checking (via private
                     email) availability of the review manager and library


### PR DESCRIPTION
Based on @glenfe's clarification https://github.com/boostorg/website/pull/534#issuecomment-678422348
I received as answer to my question https://github.com/boostorg/website/pull/534#issuecomment-678415872

------

The clarification is consistently added to notes for each of the three initial actors of the review scheduling process.