### PR TITLE
Add description of the config top level directory

### DIFF
--- a/development/requirements.html
+++ b/development/requirements.html
@@ -271,6 +271,20 @@ https://www.boost.org/development/website_updating.html
                   </tr>
 
                   <tr>
+                    <td><code>config</code></td>
+
+                    <td>Files used for build-time configuration checks. This
+                    directory may contain source files and build system
+                    scripts to be used when building the library, tests or
+                    examples to check if the target system satisfies certain
+                    conditions. For example, a check may test if the compiler
+                    implements a certain feature, or if the target system
+                    supports a certain API.</td>
+
+                    <td>Optional.</td>
+                  </tr>
+
+                  <tr>
                     <td><code>doc</code></td>
 
                     <td>Sources to build with and built documentation for the


### PR DESCRIPTION
The config top level directory in the library structure contains build-time configuration checks. This directory is already used in this way in a number of libraries, and more and more libraries wish to add new build-time checks. This commit provides a guideline where such check could be placed.