### PR TITLE
Update library doc page with 'Standard' field removed

### DIFF
--- a/common/code/boost_libraries.php
+++ b/common/code/boost_libraries.php
@@ -116,18 +116,6 @@ class BoostLibraries
                         else { $lib[$val['tag']] = ''; }
                     }
                     break;
-                    case 'std-proposal':
-                    case 'std-tr1':
-                    {
-                        $value = isset($val['value']) ? trim($val['value']) : false;
-                        if($value && $value != 'true' && $value != 'false') {
-                            throw new BoostLibraries_DecodeException(
-                                "Invalid value for {$val['tag']}: {$value}",
-                                $xml);
-                        }
-                        $lib[$val['tag']] = ($value == 'true');
-                    }
-                    break;
                     case 'authors':
                     case 'maintainers':
                     case 'category':

--- a/common/code/boost_utility.php
+++ b/common/code/boost_utility.php
@@ -56,12 +56,9 @@ class BoostUtility
     static function cmp_pubdate($a,$b)
     { return cmp_less($b['pubdate'],$a['pubdate']); }
 
-    static function cmp_std_proposal($a,$b)
-    { return self::cmp(cmp_less($a['std-proposal'],$b['std-proposal']),$a,$b); }
-
-    static function cmp_std_tr1($a,$b)
-    { return self::cmp(cmp_less($a['std-tr1'],$b['std-tr1']),$a,$b); }
-
     static function cmp_title($a,$b)
     { return strcmp($a['title'],$b['title']); }
+
+    static function cmp_cxxstd($a,$b)
+    { return strcmp($a['cxxstd'],$b['cxxstd']); }
 }

--- a/doc/libraries.php
+++ b/doc/libraries.php
@@ -21,8 +21,6 @@ class LibraryPage {
     );
 
     static $filter_fields = Array(
-        'std-proposal' => 'Standard Proposals',
-        'std-tr1' => 'TR1 libraries',
         'header-only' => '[old]',
         'autolink' => '[old]'
     );
@@ -30,14 +28,14 @@ class LibraryPage {
     static $sort_fields =  Array(
         'name' => 'Name',
         'boost-version' => 'First Release',
-        'std-proposal' => 'STD Proposal',
-        'std-tr1' => 'STD::TR1',
-        'key' => 'Key'
+        'key' => 'Key',
+        'cxxstd' => 'C++ Minimum'
     );
 
     static $display_sort_fields = Array(
         'name' => 'Name',
-        'boost-version' => 'First Release'
+        'boost-version' => 'First Release',
+        'cxxstd' => 'C++ Minimum'
     );
 
     var $params;            // Normalised URL parameters
@@ -242,17 +240,6 @@ class LibraryPage {
             '<i>'.html_encode($lib['boost-version']).'</i>';
     }
 
-    function libstandard($lib) {
-        $p = array();
-        if ($lib['std-proposal']) {
-            $p[] = 'Proposed';
-        }
-        if ($lib['std-tr1']) {
-            $p[] = 'TR1';
-        }
-        print ($p ? implode(', ', $p) : '&nbsp;');
-    }
-
     function libstandard_min_level($lib) {
         print !empty($lib['cxxstd']) ?
                 html_encode($lib['cxxstd']) : '&nbsp;';
@@ -371,8 +358,6 @@ if (!is_dir($library_page->documentation_page->documentation_dir())) {
                     <dd><?php $library_page->libauthors($lib); ?></dd>
                     <dt>First&nbsp;Release</dt>
                     <dd><?php $library_page->libavailable($lib); ?></dd>
-                    <dt>Standard</dt>
-                    <dd><?php $library_page->libstandard($lib); ?></dd>
                     <?php if (isset($lib['cxxstd'])): ?>
                     <dt>C++ standard minimum level</dt>
                     <dd><?php $library_page->libstandard_min_level($lib); ?></dd>


### PR DESCRIPTION
- Remove 'Standard' field from each library info
- Remove 'Standard Proposals' and 'TR1 libraries' from sort categories
- Add 'C++ Minimum' to sort categories