### PR TITLE
Add secondary sort by name to C++ Minimum (cxxstd)

### DIFF
--- a/common/code/boost_libraries.php
+++ b/common/code/boost_libraries.php
@@ -120,7 +120,6 @@ class BoostLibraries
                     case 'authors':
                     case 'maintainers':
                     case 'category':
-                    case 'std':
                     {
                         if(isset($val['value'])) {
                             $name = trim($val['value']);

--- a/common/code/boost_utility.php
+++ b/common/code/boost_utility.php
@@ -60,5 +60,5 @@ class BoostUtility
     { return strcmp($a['title'],$b['title']); }
 
     static function cmp_cxxstd($a,$b)
-    { return strcmp($a['cxxstd'],$b['cxxstd']); }
+    { return self::cmp(strcmp($a['cxxstd'],$b['cxxstd']),$a,$b); }
 }


### PR DESCRIPTION
- Added secondary sort by library's name on same cxxstd values When sorting by C++ Minimum
- Removed 'std' from XML parsing as it has been removed from the XML file by the latest build.