### PR TITLE
Lock mustache/spec to sha in composer.lock

### DIFF
--- a/common/code/test/composer.json
+++ b/common/code/test/composer.json
@@ -10,7 +10,7 @@
                 "source": {
                     "url": "https://github.com/mustache/spec.git",
                     "type": "git",
-                    "reference": "master"
+                    "reference": "41d1eb385676cf6a673b8d612b6ab5cdfd5a660c"
                 }
             }
         }

--- a/common/code/test/composer.lock
+++ b/common/code/test/composer.lock
@@ -1,11 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "65c5acf5ce7a3b088d397b7ecb67ae31",
-    "content-hash": "e5a5efd8a5f54b732cf2ead776707d51",
+    "content-hash": "5a1f79cadb3a9ce2f22dfd53d42eba04",
     "packages": [
         {
             "name": "mustache/spec",
@@ -13,10 +12,9 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mustache/spec.git",
-                "reference": "master"
+                "reference": "41d1eb385676cf6a673b8d612b6ab5cdfd5a660c"
             },
-            "type": "library",
-            "time": "2015-02-22 23:42:57"
+            "type": "library"
         },
         {
             "name": "nette/tester",
@@ -72,7 +70,7 @@
                 "testing",
                 "unit"
             ],
-            "time": "2016-03-19 14:34:02"
+            "time": "2016-03-19T14:34:02+00:00"
         }
     ],
     "packages-dev": [],
@@ -82,5 +80,6 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
Travis tests are being run from the common/code/test/ folder.
It contains composer.json and composer.lock files.
Lock all composer packages to known working versions.   