### PR TITLE
Adjust B2 name and link to "local" direct location.

### DIFF
--- a/common/code/boost_site_tools.php
+++ b/common/code/boost_site_tools.php
@@ -248,7 +248,7 @@ EOL;
       <a href="/doc/tools.html">Tools <span class="link">&gt;</span></a>
 
       <ul>
-        <li><a href="/build/">Boost Build <span class=
+        <li><a href="/tools/build/">B2 <span class=
         "link">&gt;</span></a></li>
 
         <li><a href="/tools/regression/">Regression <span class=

--- a/common/code/boost_site_tools.php
+++ b/common/code/boost_site_tools.php
@@ -248,7 +248,7 @@ EOL;
       <a href="/doc/tools.html">Tools <span class="link">&gt;</span></a>
 
       <ul>
-        <li><a href="/tools/build/">B2 <span class=
+        <li><a href="/tools/build/">Boost Build <span class=
         "link">&gt;</span></a></li>
 
         <li><a href="/tools/regression/">Regression <span class=


### PR DESCRIPTION
This changes to the current name of the build tool and, like the other tools, moves the link to the canonical "tools/build" location.