### PR TITLE
Add GIL release notes for Boost 1.76.0

### DIFF
--- a/feed/history/boost_1_76_0.qbk
+++ b/feed/history/boost_1_76_0.qbk
@@ -46,6 +46,10 @@ Please keep the list of libraries sorted in lexicographical order.
     [@/libs/beast/doc/html/beast/release_notes.html Release Notes]
     for a complete list of changes.
 
+* [phrase library..[@/libs/gil/ GIL]:]
+  * BREAKING: In next release, we are going to drop support for GCC 5.
+    We will also change the required minimum C++ version from C++11 to C++14.
+
 * [phrase library..[@/libs/poly_collection/ PolyCollection]:]
   * Worked around [@https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95888 GCC bug]
     affecting GCC versions 9.3-10.2 (issue [github poly_collection 20]).


### PR DESCRIPTION
Nothing new, just carrying over the important notice from the Boost 1.75.0 notes (#562).