### PR TITLE
Fix typo in 1.76.0 release notes

### DIFF
--- a/feed/history/boost_1_76_0.qbk
+++ b/feed/history/boost_1_76_0.qbk
@@ -63,7 +63,7 @@ Please keep the list of libraries sorted in lexicographical order.
 
 * [phrase library..[@/libs/multiprecision/ Multiprecision]:]
   * [*BREAKING CHANGE]: Massive refactoring and code simpification makes C++11 an absolute requirement.
-  * Use BOOST_TRY/CATCH in headers so code can be use din s=exception-free environments.
+  * Use BOOST_TRY/CATCH in headers so code can be used in exception-free environments.
   * Correct corner case in pow, fixes [@https://github.com/boostorg/multiprecision/issues/277 #277]. 
   * Correct exception type thrown to match docs in lsb/msb: fixes [@https://github.com/boostorg/multiprecision/issues/257 #257].
   * Allow moves and operators between related but different types (ie types with the same allocator), fixes [@https://github.com/boostorg/multiprecision/issues/278 #278].


### PR DESCRIPTION
Not sure if `s=` is some special fomatting.