### PR TITLE
Update website doc

### DIFF
--- a/development/website_updating.html
+++ b/development/website_updating.html
@@ -357,6 +357,7 @@ define('BOOST_WEBSITE_SHARED_DIR', '/path/to/boost/shared');
 define('STATIC_DIR', '/path/to/boost/shared/archives/live');
 ?&gt;
 </pre>
+                  <p>When setting up an official web server, the file should instead be called config.php, and placed at the path "<tt>/home/www/shared/config.php</tt>".
 
                   <p>For a brief explanation of the settings see the
                   <tt><a href=
@@ -365,12 +366,7 @@ define('STATIC_DIR', '/path/to/boost/shared/archives/live');
                 </li>
 
                 <li>
-                  <p>In order to view the documentation, or the build
-                  sub-site, you'll need to setup the appropriate directories.
-                  <tt>/build</tt> needs to contain the <a href=
-                  "https://github.com/boostorg/build/tree/website"><tt>website</tt>
-                  branch of Boost.Build</a>. A soft link to another directory
-                  can be used here (which is how it's done on the server).
+                  <p>In order to view the documentation you'll need to set up the appropriate directories.
                   <tt>STATIC_DIR</tt> needs to be the location of unzipped
                   copies of the appropriate boost distribution to serve the
                   documentation. By default, boost_config.php sets STATIC_DIR


### PR DESCRIPTION
The documentation for configuring the website had mentioned a requirement to have the "website branch of Boost.Build".   However, the website branch of Boost.Build does not exist.    If this should be modified in a different way, let me know.