### PR TITLE
Add a post-release not and patch for Boost.Build fixing library installs

### DIFF
--- a/feed/history/boost_1_78_0.qbk
+++ b/feed/history/boost_1_78_0.qbk
@@ -3,7 +3,7 @@
     [source-mode c++]
     [purpose
         Updated Libraries: Asio, Assert, Atomic, Beast, Core, Describe, DLL,
-        Filesystem, Geometry, JSON, Lambda2, Log, Math, MultiIindex,
+        Filesystem, Geometry, JSON, Lambda2, Log, Math, MultiIndex,
         Multiprecision, PFR, Predef, Regex, System, Utility, Variant2.
         [/ Please don't add updated libraries yet, it
            can create unnecessary merge conflicts.]
@@ -19,6 +19,17 @@
 Formatting reference: https://www.boost.org/doc/tools/quickbook/
 Please keep the list of libraries sorted in lexicographical order.
 ]
+
+[section Known Issues]
+
+These are patches from library authors which were found too late to be fixed
+in the release.
+
+* Boost.Build silently skips installation of library headers and binaries in some cases,
+  see [@https://github.com/bfgroup/b2/issues/104 #104].
+  * Fixed in [@https://github.com/bfgroup/b2/pull/113 PR#113], [@/patches/1_78_0/0001-b2-fix-install.patch patch].
+
+[endsect]
 
 [section New Libraries]
 

--- a/patches/1_78_0/0001-b2-fix-install.patch
+++ b/patches/1_78_0/0001-b2-fix-install.patch
@@ -1,0 +1,80 @@
+https://github.com/bfgroup/b2/pull/113
+
+From 62e7321669f66a90e2a90c8f31af34f59ebc5d7a Mon Sep 17 00:00:00 2001
+From: Dmitry Arkhipov <grisumbras@gmail.com>
+Date: Thu, 9 Dec 2021 08:11:57 +0300
+Subject: [PATCH] Don't skip install targets if there's <build>no in ureqs
+
+---
+ src/tools/stage.jam      |  4 ++++
+ test/install_build_no.py | 26 ++++++++++++++++++++++++++
+ test/test_all.py         |  1 +
+ 3 files changed, 31 insertions(+)
+ create mode 100755 test/install_build_no.py
+
+Index: boost_1_78_0/tools/build/src/tools/stage.jam
+===================================================================
+--- boost_1_78_0.orig/tools/build/src/tools/stage.jam	2021-12-09 16:30:45.956457531 +0300
++++ boost_1_78_0/tools/build/src/tools/stage.jam	2021-12-09 16:30:45.952457519 +0300
+@@ -476,10 +476,14 @@ class install-target-class : basic-targe
+         }
+         DELETE_MODULE $(result) ;
+         return [ sequence.unique $(result2) ] ;
+     }
+ 
++    rule skip-from-usage-requirements ( )
++    {
++    }
++
+     # Returns true iff 'type' is subtype of some element of 'types-to-include'.
+     #
+     local rule include-type ( type : types-to-include * )
+     {
+         local found ;
+Index: boost_1_78_0/tools/build/test/install_build_no.py
+===================================================================
+--- /dev/null	1970-01-01 00:00:00.000000000 +0000
++++ boost_1_78_0/tools/build/test/install_build_no.py	2021-12-09 16:30:45.953457522 +0300
+@@ -0,0 +1,26 @@
++#!/usr/bin/python
++
++# Copyright 2021 Dmitry Arkhipov (grisumbras@gmail.com)
++# Distributed under the Boost Software License, Version 1.0.
++# (See accompanying file LICENSE.txt or https://www.bfgroup.xyz/b2/LICENSE.txt)
++
++# Check that <build>no in usage-requirements of dependencies does not affect
++# install rule, i.e. a skipped installed target does not affect insallation of
++# other targets.
++
++import BoostBuild
++
++t = BoostBuild.Tester()
++
++t.write("a.cpp", "int main() {}\n")
++
++t.write("jamroot.jam", """
++make x : : maker : <build>no ;
++exe a : a.cpp ;
++install install : x a ;
++""")
++
++t.run_build_system()
++t.expect_addition("install/a.exe")
++
++t.cleanup()
+Index: boost_1_78_0/tools/build/test/test_all.py
+===================================================================
+--- boost_1_78_0.orig/tools/build/test/test_all.py	2021-12-09 16:30:45.956457531 +0300
++++ boost_1_78_0/tools/build/test/test_all.py	2021-12-09 16:30:45.953457522 +0300
+@@ -248,10 +248,11 @@ tests = ["abs_workdir",
+          "implicit_dependency",
+          "indirect_conditional",
+          "inherit_toolset",
+          "inherited_dependency",
+          "inline",
++         "install_build_no",
+          "libjpeg",
+          "liblzma",
+          "libpng",
+          "libtiff",
+          "libzstd",

--- a/patches/index.html
+++ b/patches/index.html
@@ -33,6 +33,12 @@ https://www.boost.org/development/website_updating.html
               late to be fixed in the release. Be careful as they have
               not been through the normal testing process.</p>
 
+            <h2>1.78.0</h2>
+
+            <ul>
+              <li><a href="1_78_0/0001-b2-fix-install.patch">0001-b2-fix-install.patch</a></li>
+            </ul>
+
             <h2>1.73.0</h2>
 
             <ul>


### PR DESCRIPTION
In Boost 1.78.0, `b2 install` does not install Boost.Stacktrace binaries on Linux. Add a post-prelease note with a patch.

Related issue: https://github.com/bfgroup/b2/issues/104
Related PR: https://github.com/bfgroup/b2/pull/113
