### PR TITLE
1.80.0 : fix typo of GIL function name

### DIFF
--- a/feed/history/boost_1_80_0.qbk
+++ b/feed/history/boost_1_80_0.qbk
@@ -77,7 +77,7 @@ Please keep the list of libraries sorted in lexicographical order.
       the preference of the Boost.Filesystem.
     * Renamed `pixel_multiply_t` to `pixel_multiplies_t` and `pixel_divide_t` to `pixel_divides_t` ([github_pr gil 655])
     * Renamed `io/dynamic_io_new.hpp` to `io/detail/dynamic.hpp` ([github_pr gil 653])
-    * Moved function `construct_method` into `boost::gil::detail` namespace as it was only used by other implementation details ([github_pr gil 653])
+    * Moved function `construct_matched` into `boost::gil::detail` namespace as it was only used by other implementation details ([github_pr gil 653])
     * Made `packed_pixel` trivially copyable and assignable ([github_pr gil 679])
     * Replace deprecated libtiff v4.3 typedefs with C99 fixed-size integers ([github_pr gil 685])
   * Removed


### PR DESCRIPTION
s/construct_method/construct_matched/
https://github.com/boostorg/gil/pull/653