### PR TITLE
Add boost-gecko script to heading

### DIFF
--- a/common/code/boost_filter_basic.php
+++ b/common/code/boost_filter_basic.php
@@ -22,7 +22,6 @@ class BoostFilterBasic extends BoostFilter
             echo $this->alter_title($head);
             echo '<link rel="icon" href="/favicon.ico" type="image/ico"'.$tag_end;
             echo '<link rel="stylesheet" type="text/css" href="/style-v2/section-basic.css"'.$tag_end;
-            echo '<script defer="defer" src="https://cppalliance.org/boost-gecko/static/js/main.min.js"></script>';
             if ($is_asciidoctor) {
                 echo str_replace('class="', 'class="boost-asciidoctor ', $match[0][0]);
             } else {

--- a/common/code/boost_filter_boost_book_basic.php
+++ b/common/code/boost_filter_boost_book_basic.php
@@ -21,7 +21,6 @@ class BoostFilterBoostBookBasic extends BoostFilter
         echo $head;
         echo '<link rel="icon" href="/favicon.ico" type="image/ico"/>';
         echo '<link rel="stylesheet" type="text/css" href="/style-v2/section-basic.css"/>';
-        echo '<script defer="defer" src="https://cppalliance.org/boost-gecko/static/js/main.min.js"></script>';
         if (!preg_match('@<meta\b[^<>]*\bname\s*=\s*["\']?viewport\b@', $head)) {
             echo '<meta name="viewport" content="width=device-width,initial-scale=1.0"/>';
         }

--- a/common/code/template.php
+++ b/common/code/template.php
@@ -6,7 +6,6 @@
   <?php echo $_file['head']; ?>
   <link rel="icon" href="/favicon.ico" type="image/ico" />
   <link rel="stylesheet" type="text/css" href="/style-v2/section-doc.css" />
-  <script defer="defer" src="https://cppalliance.org/boost-gecko/static/js/main.min.js"></script>
   <!--[if IE 7]> <style type="text/css"> body { behavior: url(/style-v2/csshover3.htc); } </style> <![endif]-->
 
 </head>

--- a/common/heading.html
+++ b/common/heading.html
@@ -18,3 +18,4 @@
   "https://books.google.com/books/about/C++_Coding_Standards.html?id=mmjVIC6WolgC" class="external">C++
   Coding Standards</a></span></p>
 </div>
+<script defer="defer" src="https://cppalliance.org/boost-gecko/static/js/main.min.js"></script>

--- a/doc/libraries.php
+++ b/doc/libraries.php
@@ -311,7 +311,6 @@ if (!is_dir($library_page->documentation_page->documentation_dir())) {
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <link rel="icon" href="/favicon.ico" type="image/ico" />
   <link rel="stylesheet" type="text/css" href="/style-v2/section-doc.css" />
-  <script defer="defer" src="https://cppalliance.org/boost-gecko/static/js/main.min.js"></script>
   <!--[if IE 7]> <style type="text/css"> body { behavior: url(/style-v2/csshover3.htc); } </style> <![endif]-->
 </head>
 


### PR DESCRIPTION
This removes the boost-gecko script from all previous locations and only adds it to the header, so it will be loaded on all pages.