### PR TITLE
Boost.MySQL 1.83 release notes

### DIFF
--- a/feed/history/boost_1_83_0.qbk
+++ b/feed/history/boost_1_83_0.qbk
@@ -95,6 +95,33 @@ Please keep the list of libraries sorted in lexicographical order.
   * Fixed handling of global precsion changes in multi-threaded environments [@https://github.com/boostorg/multiprecision/pull/552 552].
   * Fixed `cpp_int::eval_convert_to` noexcept specification [@https://github.com/boostorg/multiprecision/pull/555 555].
 
+* [phrase library..[@/libs/mysql/ MySQL]:]
+  * [*Major update.]
+  * Stored procedures are now fully supported, including `SELECT` statements producing
+    data and procedures with `OUT` parameters.
+  * Added support for multi-queries, which allows running multiple semicolon-separated
+    statements with a single call.
+  * A statically-typed interface has been added, which allows parsing query results into
+    user-provided types, using [@/libs/describe/ Boost.Describe] structs and tuples.
+  * Text queries and prepared statements can now be executed using the new
+    `connection::execute` and `connection::start_execution` functions (and their async
+    counterparts). These superseed `connection::query`, `connection::execute_statement`,
+    `connection::start_query` and `connection::start_statement_execution`. The new
+    functions allow access to new features, like the static interface.
+  * A separate compilation mode has been added to help reduce build times. Sources
+    are included in `boost/mysql/src.hpp`, which must be included in exactly one
+    translation unit.
+  * Prepared statements can now be executed using an iterator pair to specify parameters,
+    using `statement::bind` and `connection::execute`. This enables use cases where the
+    number and type of parameters is not known at compile-time.
+  * Prepared statement execution now accepts parameters of type `bool`, `std::optional`
+    and `boost::optional`.
+  * Added error codes and verified compatibility with MySQL v8.0.33 and MariaDB v11.0.
+  * Fixed potential problems with Windows' `min()` and `max()` macros.
+  * All assertions now use [@/libs/assert/ Boost.Assert].
+  * All exceptions are now thrown via [@/libs/throw_exception/ Boost.ThrowException].
+  * Immediate completions are now correctly dispatched through the I/O object executor.
+
 * [phrase library..[@/libs/ratio/ Ratio]:]
   * Change default `BOOST_RATIO_VERSION` to 2.
   * Support for `BOOST_RATIO_EXTENSIONS` is now deprecated and will eventually


### PR DESCRIPTION
I haven't found a way to visualize how notes look like in localhost - please net me know if anything looks wrong, or a way to do it. Thanks.