### PR TITLE
Add known issue and patch for JSON

### DIFF
--- a/feed/history/boost_1_83_0.qbk
+++ b/feed/history/boost_1_83_0.qbk
@@ -19,6 +19,17 @@ Formatting reference: https://www.boost.org/doc/tools/quickbook/
 Please keep the list of libraries sorted in lexicographical order.
 ]
 
+[section Known Issues]
+
+These are patches from library authors which were found too late to be fixed
+in the release.
+
+* JSON
+  * Compilation on Windows ARM platforms may fail for missing intrinsics, see [github json 926] and [github json 927].
+    [@https://github.com/boostorg/json/commit/c4ce8509d015a0b75cfa9d36609b8409821a9c86.patch Patch].
+
+[endsect]
+
 [section New Libraries]
 
 [/ Example:


### PR DESCRIPTION
Add a known issue and patch for Boost.JSON not compiling on Windows ARM platforms for missing intrinsics. Both of the issues came in simultaneously.

CC: @grisumbras 