### PR TITLE
Host boost downloads on AWS Cloudfront

### DIFF
--- a/generated/download-items.html
+++ b/generated/download-items.html
@@ -16,9 +16,9 @@
 
 <ul class="menu">
 <li><a href="/users/history/version_1_84_0.html">Release Notes</a></li>
-<li><a href="https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/">Download</a></li>
+<li><a href="https://archives.boost.io/release/1.84.0/source/">Download</a></li>
 <li><a href="/doc/libs/1_84_0/">Documentation</a></li>
 </ul>
               <table class="download-table"><caption>Downloads</caption><tr><th scope="col">Platform</th><th scope="col">File</th><th scope="col">SHA256 Hash</th></tr>
-<tr><th scope="row" rowspan="2">unix</th><td><a href="https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.tar.bz2">boost_1_84_0.tar.bz2</a></td><td>cc4b893acf645c9d4b698e9a0f08ca8846aa5d6c68275c14c3e7949c24109454</td></tr><tr><td><a href="https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.tar.gz">boost_1_84_0.tar.gz</a></td><td>a5800f405508f5df8114558ca9855d2640a2de8f0445f051fa1c7c3383045724</td></tr>
-<tr><th scope="row" rowspan="2">windows</th><td><a href="https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.7z">boost_1_84_0.7z</a></td><td>81a4d10075731966477276c47324ecd9cac02da49899d36c48eba66e40014f25</td></tr><tr><td><a href="https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.zip">boost_1_84_0.zip</a></td><td>cc77eb8ed25da4d596b25e77e4dbb6c5afaac9cddd00dc9ca947b6b268cc76a4</td></tr></table>
+<tr><th scope="row" rowspan="2">unix</th><td><a href="https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2">boost_1_84_0.tar.bz2</a></td><td>cc4b893acf645c9d4b698e9a0f08ca8846aa5d6c68275c14c3e7949c24109454</td></tr><tr><td><a href="https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.gz">boost_1_84_0.tar.gz</a></td><td>a5800f405508f5df8114558ca9855d2640a2de8f0445f051fa1c7c3383045724</td></tr>
+<tr><th scope="row" rowspan="2">windows</th><td><a href="https://archives.boost.io/release/1.84.0/source/boost_1_84_0.7z">boost_1_84_0.7z</a></td><td>81a4d10075731966477276c47324ecd9cac02da49899d36c48eba66e40014f25</td></tr><tr><td><a href="https://archives.boost.io/release/1.84.0/source/boost_1_84_0.zip">boost_1_84_0.zip</a></td><td>cc77eb8ed25da4d596b25e77e4dbb6c5afaac9cddd00dc9ca947b6b268cc76a4</td></tr></table>

--- a/generated/home-items.html
+++ b/generated/home-items.html
@@ -3,7 +3,7 @@
 <div id="downloads">
 <h3>Current Release</h3>
 <ul>
-<li><div class="news-title"><a href="/users/history/version_1_84_0.html">Version 1.84.0</a></div><div class="news-date"><a href="/users/history/version_1_84_0.html">Release Notes</a> | <a href="https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/">Download</a> | <a href="/doc/libs/1_84_0/">Documentation</a></div><div class="news-date">December 13th, 2023 23:54 GMT</div></li>
+<li><div class="news-title"><a href="/users/history/version_1_84_0.html">Version 1.84.0</a></div><div class="news-date"><a href="/users/history/version_1_84_0.html">Release Notes</a> | <a href="https://archives.boost.io/release/1.84.0/source/">Download</a> | <a href="/doc/libs/1_84_0/">Documentation</a></div><div class="news-date">December 13th, 2023 23:54 GMT</div></li>
 </ul>
 </div>
 <p><a href="/users/download/">More Downloads...</a> (<a href="feed/downloads.rss">RSS</a>)</p>

--- a/users/history/version_1_84_0.html
+++ b/users/history/version_1_84_0.html
@@ -42,8 +42,8 @@
               <p><span class=news-date">December 13th, 2023 23:54 GMT</span></p>
               <p><a href="/doc/libs/1_84_0/">Documentation</a>
               <table class="download-table"><caption>Downloads</caption><tr><th scope="col">Platform</th><th scope="col">File</th><th scope="col">SHA256 Hash</th></tr>
-<tr><th scope="row" rowspan="2">unix</th><td><a href="https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.tar.bz2">boost_1_84_0.tar.bz2</a></td><td>cc4b893acf645c9d4b698e9a0f08ca8846aa5d6c68275c14c3e7949c24109454</td></tr><tr><td><a href="https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.tar.gz">boost_1_84_0.tar.gz</a></td><td>a5800f405508f5df8114558ca9855d2640a2de8f0445f051fa1c7c3383045724</td></tr>
-<tr><th scope="row" rowspan="2">windows</th><td><a href="https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.7z">boost_1_84_0.7z</a></td><td>81a4d10075731966477276c47324ecd9cac02da49899d36c48eba66e40014f25</td></tr><tr><td><a href="https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.zip">boost_1_84_0.zip</a></td><td>cc77eb8ed25da4d596b25e77e4dbb6c5afaac9cddd00dc9ca947b6b268cc76a4</td></tr></table>
+<tr><th scope="row" rowspan="2">unix</th><td><a href="https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2">boost_1_84_0.tar.bz2</a></td><td>cc4b893acf645c9d4b698e9a0f08ca8846aa5d6c68275c14c3e7949c24109454</td></tr><tr><td><a href="https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.gz">boost_1_84_0.tar.gz</a></td><td>a5800f405508f5df8114558ca9855d2640a2de8f0445f051fa1c7c3383045724</td></tr>
+<tr><th scope="row" rowspan="2">windows</th><td><a href="https://archives.boost.io/release/1.84.0/source/boost_1_84_0.7z">boost_1_84_0.7z</a></td><td>81a4d10075731966477276c47324ecd9cac02da49899d36c48eba66e40014f25</td></tr><tr><td><a href="https://archives.boost.io/release/1.84.0/source/boost_1_84_0.zip">boost_1_84_0.zip</a></td><td>cc77eb8ed25da4d596b25e77e4dbb6c5afaac9cddd00dc9ca947b6b268cc76a4</td></tr></table>
               <div class="news-description">
                 <div class="description">
 


### PR DESCRIPTION
These webpages are in the "generated/" folder of the website.  We'll have to see if they can be manually updated or will be re-generated.  