### PR TITLE
Adding Slack link

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,17 +79,19 @@ http://www.boost.org/development/website_updating.html
                   <a href="/users/">introductory material</a> to help you
                   understand what Boost is about and to help in educating
                   your organization about Boost.</span></p>
+                </div>
 
-                  <h3 class="note">Community</h3>
+                <div class="directory-item" id="important-downloads">
+                  <h2>Community</h2>
 
                   <p class="note"><span class="note-body">Boost welcomes and
                   thrives on participation from a variety of individuals and
                   organizations. Many avenues for participation are available
                   in the <a href="/community/">Boost
                   Community</a>.</span></p>
-                </div>
 
-                <div class="directory-item" id="important-downloads">
+                  <p class="note">Visit the Official C++ Language Slack Workspace at <a href="https://cpplang.slack.com/" class="external">https://cpplang.slack.com</a>! Sign up at <a href="https://cpp.al/slack" class="external">https://cpp.al/slack</a>.</p>
+
                   <h2>Downloads</h2>
 
                   <ul id="downloads">


### PR DESCRIPTION
This adds a link to the C++ Slack workspace.  

Tested under all breakpoints for various screen resolutions so it should render fairly well, but we can tweak it if there are any glitches.