### PR TITLE
Release note for boost::format requiring C++11 in 1.86.0

### DIFF
--- a/feed/history/boost_1_86_0.qbk
+++ b/feed/history/boost_1_86_0.qbk
@@ -46,6 +46,10 @@ Please keep the list of libraries sorted in lexicographical order.
   * Removed dependencies on Array, Config, Integer, and TypeTraits. The
     library is now standalone.
 
+* [phrase library..[@/libs/format/ Format]:]
+  * C++03 is no longer supported; a C++11 compiler is required.
+    (This includes GCC 4.7 or later, and MSVC 12.0 (VS 2013) or later.)
+
 * [phrase library..[@/libs/function/ Function]:]
   * Removed dependency on Boost.TypeTraits.
 


### PR DESCRIPTION
Some dependencies of boost::format dropped C++03 support.  Although boost::format had no deprecation period, the issue was forced.

I am not a fan of the per-library C++ level support and supported compilers.  It would be easier for consumers if we all agreed on this and all moved forward together.

This closes jeking3/format#96