### PR TITLE
Add a section regarding email footers

### DIFF
--- a/community/policy.html
+++ b/community/policy.html
@@ -53,6 +53,7 @@ https://www.boost.org/development/website_updating.html
                 <li><a href="#summarizing-referring">Summarizing and Referring to Earlier Messages</a></li>
                 <li><a href="#discussion-threads">Maintain the Integrity of Discussion Threads</a></li>
                 <li><a href="#max-size">Keep The Size of Your Posting Manageable</a></li>
+                <li><a href="#email-footers">Avoid Corporate and Confidentiality Footers in Your Emails</a></li>
               </ul>
 
                 </li>
@@ -255,7 +256,7 @@ Your response to the second part of the message goes here.
               hide or kill the entire thread: your message will be missed,
               and you won't get the response you're looking for.</p>
 
-              <p>By the same token, <strong>When replying to an existing
+              <p>By the same token, <strong>when replying to an existing
               message, use your mailer's "Reply" function</strong>, so that
               the reply shows up as part of the same discussion thread.</p>
 
@@ -275,6 +276,32 @@ Your response to the second part of the message goes here.
               face it, no one wants to read a posting that consists of 75K of 
               error message text.</p>
 
+              <h3><a name="email-footers"/>Avoid Corporate and Confidentiality
+              Footers in Your Emails</h3>
+
+              <p>Remember that mailing lists are publicly viewable, including
+              by people not subscribed to the list. The responsibility of not
+              posting any confidential information is always on the sender,
+              and any confidentiality notice you may have in your email is void.
+              Sending an email with a confidentiality footer is a one-way action
+              by the sender, and the receiver has no way to accept or reject the
+              terms specified in the footer. As such, the footer is not binding,
+              but may come across as imposing on the receiver. This negative
+              reception will reduce the likelihood of your message being
+              answered.</p>
+
+              <p>Additionally, if your footer contains corporate information,
+              such as company name, logo, marketing slogans, contacts, and your
+              position within the company, this may be taken as advertisement,
+              which is explicitly forbidden. If your message requires you to
+              expose your corporate affiliation, please include this information
+              in the body of your message instead of attaching it to your every
+              post in the corporate footer.</p>
+
+              <p>If the footer is a mandatory corporate policy then please avoid
+              using corporate email accounts for sending posts to the mailing
+              lists. Use a non-corporate email account instead.</p>
+                
               <h2><a name="behavior" id="behavior"></a>Prohibited
               Behavior</h2>
 


### PR DESCRIPTION
Add a section that strongly recommends avoiding corporate and confidentiality notices in email footers.

This is similar to https://github.com/boostorg/website-v2-docs/pull/252.
