### PR TITLE
Fix rendering of the section regarding email footers

### DIFF
--- a/community/policy.html
+++ b/community/policy.html
@@ -276,7 +276,7 @@ Your response to the second part of the message goes here.
               face it, no one wants to read a posting that consists of 75K of 
               error message text.</p>
 
-              <h3><a name="email-footers"/>Avoid Corporate and Confidentiality
+              <h3><a name="email-footers"></a>Avoid Corporate and Confidentiality
               Footers in Your Emails</h3>
 
               <p>Remember that mailing lists are publicly viewable, including


### PR DESCRIPTION
Apparently, the self-closed `<a name"email-footers"/>` tag is not allowed and breaks rendering of the section body in Firefox 128. Convert it to an open+close pair.