### PR TITLE
Update links to BoostBook documentation

### DIFF
--- a/common/code/boost_site_tools.php
+++ b/common/code/boost_site_tools.php
@@ -257,7 +257,7 @@ EOL;
         <li><a href="/tools/inspect/">Inspect <span class=
         "link">&gt;</span></a></li>
 
-        <li><a href="/doc/html/boostbook.html">BoostBook <span class=
+        <li><a href="/tools/boostbook/">BoostBook <span class=
         "link">&gt;</span></a></li>
 
         <li><a href="/tools/quickbook/">QuickBook <span class=

--- a/community/groups.html
+++ b/community/groups.html
@@ -243,7 +243,7 @@ https://www.boost.org/development/website_updating.html
               list</h3>
 
               <p>The mailing list for the <a href=
-              "/doc/libs/release/doc/html/boostbook.html">Boost Documentation
+              "/doc/libs/release/tools/boostbook/index.html">Boost Documentation
               System</a> is located <a href=
               "https://lists.boost.org/mailman/listinfo.cgi/boost-docs" class=
               "external">here</a>.</p>

--- a/doc/tools.html
+++ b/doc/tools.html
@@ -54,7 +54,7 @@ https://www.boost.org/development/website_updating.html
                 <dd>The inspection tool used to detect errors in the Boost
                 directory hierarchy.</dd>
 
-                <dt><a href="../doc/html/boostbook.html">BoostBook</a></dt>
+                <dt><a href="tools/boostbook/index.html">BoostBook</a></dt>
 
                 <dd>A Boost documentation system, based on <a href=
                 "http://www.docbook.org/">DocBook</a> and the <a href=
@@ -72,7 +72,7 @@ https://www.boost.org/development/website_updating.html
                 <dd>QuickBook is a WikiWiki style documentation tool geared
                 towards C++ documentation using simple rules and markup for
                 simple formatting tasks. QuickBook generates <a href=
-                "../doc/html/boostbook.html">BoostBook</a> XML.</dd>
+                "tools/boostbook/index.html">BoostBook</a> XML.</dd>
 
                 <dt><a href="../libs/wave/doc/wave_driver.html">Wave</a></dt>
 

--- a/generated/menu-doc.html
+++ b/generated/menu-doc.html
@@ -201,7 +201,7 @@
         <li><a href="/tools/inspect/">Inspect <span class=
         "link">&gt;</span></a></li>
 
-        <li><a href="/doc/html/boostbook.html">BoostBook <span class=
+        <li><a href="/tools/boostbook/">BoostBook <span class=
         "link">&gt;</span></a></li>
 
         <li><a href="/tools/quickbook/">QuickBook <span class=


### PR DESCRIPTION
The main redirect page is tools/boostbook/index.html, so point all links to that page. It will then redirect to the actual place where the built BoostBook documentation is (which is currently tools/boostbook/doc/html).

Refs https://github.com/boostorg/boostbook/issues/29.