### PR TITLE
Add release notes for: Charconv, test, math, and multiprecision 

### DIFF
--- a/feed/history/boost_1_87_0.qbk
+++ b/feed/history/boost_1_87_0.qbk
@@ -135,6 +135,10 @@ Please keep the list of libraries sorted in lexicographical order.
 * [phrase library..[@/libs/mp11/ Mp11]:]
   * Added `mp_lambda` (contributed by Joaquin M Lopez Munoz)
 
+* [phrase library..[@/libs/multiprecision/ Multiprecision]:]
+  * Make `float128` trivially copyable
+  * Make `__float128` a floating point type even in non-GNU modes
+
 * [phrase library..[@/libs/mysql/ MySQL]:]
   * [*Breaking changes to experimental APIs]:
     * The thread-safety feature in `connection_pool` has been redesigned

--- a/feed/history/boost_1_87_0.qbk
+++ b/feed/history/boost_1_87_0.qbk
@@ -237,6 +237,10 @@ Please keep the list of libraries sorted in lexicographical order.
     it, but do not advertise that support via `__cpp_explicit_this_parameter`.
     ([@https://github.com/boostorg/stl_interfaces/pull/68 PR#68])
 
+* [phrase library..[@/libs/test/ Test]:]
+  * Fixed support for clang tidy with dummy conditions [github_pr test 348]
+  * Fixed dynamic linking with clang [github_pr test 431]
+
 * [phrase library..[@/libs/pfr/ PFR]:]
   * `boost::pfr::for_each_field_with_name` function was added. Many thanks
     to [@https://github.com/Baduit Lena] for the [github_pr pfr 171].

--- a/feed/history/boost_1_87_0.qbk
+++ b/feed/history/boost_1_87_0.qbk
@@ -61,6 +61,11 @@ Please keep the list of libraries sorted in lexicographical order.
   * Acknowledgements
     * Jackarain, Saleh Hatefinya, René Ferdinand Rivera Morell
 
+* [phrase library..[@/libs/charconv Charconv]:]
+  * Fixed support for PPC64LE architecture using `__ibm128` as long double format
+  * Fixed intrinsic usage with Windows ARM64 platform
+  * Fixed formatting of fixed with specified precision using `std::float128_t` or `__float128`
+
 * [phrase library..[@/libs/compat/ Compat]:]
   * Added `to_array.hpp` (contributed by Ruben Perez Hidalgo.)
 

--- a/feed/history/boost_1_87_0.qbk
+++ b/feed/history/boost_1_87_0.qbk
@@ -128,6 +128,13 @@ Please keep the list of libraries sorted in lexicographical order.
     * In case of errors indicated by thread synchronization primitives, `std::system_error` exception is thrown instead of Boost.Thread exception types.
   * Added support for C++ standard library lock types to `strictest_lock`.
 
+* [phrase library..[@/libs/math/ Math]:]
+  * [*Major update.]
+  * Many special functions, and distribuitions now support CUDA (NVCC and NVRTC) and SYCL
+  * Added mapairy, holtsmark, and saspoint5 distibutions, see [@https://github.com/boostorg/math/pull/1163 1163]
+  * Added landau distibution, see [@https://github.com/boostorg/math/pull/1159 1159]
+  * Fixed unexpected exception in beta quantile, see [@https://github.com/boostorg/math/issues/1169 1169]
+
 * [phrase library..[@/libs/move/index.html Move]:]
   *  Fixed bugs:
     *  [@https://github.com/boostorg/move/issues/56 Git Issue #56: ['"Forward declarations of std types cause compilation errors on some platforms"]].

--- a/feed/history/boost_1_87_0.qbk
+++ b/feed/history/boost_1_87_0.qbk
@@ -215,6 +215,19 @@ Please keep the list of libraries sorted in lexicographical order.
   * Heavily updated the documentation and examples to be more relevant and
     reflect the new recommended best practices.
 
+* [phrase library..[@/libs/pfr/ PFR]:]
+  * `boost::pfr::for_each_field_with_name` function was added. Many thanks
+    to [@https://github.com/Baduit Lena] for the [github_pr pfr 171].
+  * [*Significant] compilation time improvement for structures with big size and small fields count. Many thanks
+    to [@https://github.com/runer112 Zachary Wassall] for the [github_pr pfr 120].
+  * Fixed `pragma` directives.
+  * [*Initial support for C++20 Modules]. See the docs for more info.
+  * Fix unused variable warnings in core_name14_disabled.hpp. Thanks
+    to [@https://github.com/anarthal Anarthal (Rubén Pérez)] for the [github_pr pfr 183] and [github_pr pfr 187].
+  * Default limit for fields count in aggregate in C++17 was raised from 100 to 200.
+  * Fixed warning about GCC not being aware of the -Wundefined-var-template.
+  * Multiple minor improvement for compilation time.
+
 * [phrase library..[@/libs/smart_ptr/ SmartPtr]:]
   * C++03 is no longer supported, a C++11 compiler is required.
     This includes GCC 4.8 or later, and MSVC 14.0 or later.
@@ -251,19 +264,6 @@ Please keep the list of libraries sorted in lexicographical order.
 * [phrase library..[@/libs/test/ Test]:]
   * Fixed support for clang tidy with dummy conditions [github_pr test 348]
   * Fixed dynamic linking with clang [github_pr test 431]
-
-* [phrase library..[@/libs/pfr/ PFR]:]
-  * `boost::pfr::for_each_field_with_name` function was added. Many thanks
-    to [@https://github.com/Baduit Lena] for the [github_pr pfr 171].
-  * [*Significant] compilation time improvement for structures with big size and small fields count. Many thanks
-    to [@https://github.com/runer112 Zachary Wassall] for the [github_pr pfr 120].
-  * Fixed `pragma` directives.
-  * [*Initial support for C++20 Modules]. See the docs for more info.
-  * Fix unused variable warnings in core_name14_disabled.hpp. Thanks
-    to [@https://github.com/anarthal Anarthal (Rubén Pérez)] for the [github_pr pfr 183] and [github_pr pfr 187].
-  * Default limit for fields count in aggregate in C++17 was raised from 100 to 200.
-  * Fixed warning about GCC not being aware of the -Wundefined-var-template.
-  * Multiple minor improvement for compilation time.
 
 * [phrase library..[@/libs/unordered/ Unordered]:]
   * [*Major update.]


### PR DESCRIPTION
Add release notes for: Charconv, test, math, and multiprecision. Fixes the ordering of PFR.

CC: @jzmaddock, @ckormanyos, @NAThompson 