### PR TITLE
Disallow search engines on the old website

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
+Disallow: /
 Disallow: /development/         # Hide huge zip files
 Disallow: /doc/libs/1_49_0_beta1/
 Crawl-delay: 10


### PR DESCRIPTION
in order to encourage search engines to display boost content from the new website.